### PR TITLE
feat: add card payment session endpoints

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -120,6 +120,11 @@ oy: {
       postUrl: process.env.TCPP_POST_URL || '',
       currency: process.env.TCPP_CURRENCY || '360',
     },
+    paymentApi: {
+      baseUrl: process.env.PAYMENT_API_URL || '',
+      apiKey: process.env.PAYMENT_API_KEY || '',
+      apiSecret: process.env.PAYMENT_API_SECRET || '',
+    },
   },
   aws: {
     region: process.env.AWS_REGION || 'ap-southeast-1',

--- a/src/controller/card.controller.ts
+++ b/src/controller/card.controller.ts
@@ -1,0 +1,36 @@
+import { Request, Response } from 'express';
+import cardService from '../service/card.service';
+import logger from '../logger';
+
+export const createCardSession = async (_req: Request, res: Response) => {
+  try {
+    const session = await cardService.createCardSession();
+    return res.status(201).json(session);
+  } catch (err: any) {
+    return res
+      .status(err.status || 500)
+      .json({ error: err.message || 'Failed to create session' });
+  }
+};
+
+export const confirmCardSession = async (req: Request, res: Response) => {
+  try {
+    const { encryptedCard, paymentMethodOptions } = req.body;
+    const { id } = req.params;
+    const result = await cardService.confirmCardSession(
+      id,
+      encryptedCard,
+      paymentMethodOptions
+    );
+    if (result.paymentUrl) {
+      logger.info(`[CardPayment] 3DS redirect URL: ${result.paymentUrl}`);
+    }
+    return res.status(200).json(result);
+  } catch (err: any) {
+    return res
+      .status(err.status || 500)
+      .json({ error: err.message || 'Failed to confirm session' });
+  }
+};
+
+export default { createCardSession, confirmCardSession };

--- a/src/route/payment.v2.routes.ts
+++ b/src/route/payment.v2.routes.ts
@@ -1,5 +1,6 @@
 import validator from '../validation/validation';
 import { Router } from 'express';
+import cardController from '../controller/card.controller';
 
 
 const paymentRouterV2 = Router();
@@ -131,5 +132,9 @@ paymentRouterV2.get(
     ...validator.getStatusValidation,
     validator.handleValidationErrors,
 );
+
+paymentRouterV2.post('/session', cardController.createCardSession);
+
+paymentRouterV2.post('/:id/confirm', cardController.confirmCardSession);
 
 export default paymentRouterV2;

--- a/src/service/card.service.ts
+++ b/src/service/card.service.ts
@@ -1,0 +1,58 @@
+import axios from 'axios';
+import { config } from '../config';
+
+const baseUrl = config.api.paymentApi?.baseUrl || '';
+const auth = {
+  username: config.api.paymentApi?.apiKey || '',
+  password: config.api.paymentApi?.apiSecret || '',
+};
+
+const buildAuth = () =>
+  auth.username || auth.password ? { auth } : undefined;
+
+const handleError = (err: any) => {
+  const status = err.response?.status || 500;
+  const message = err.response?.data?.message || err.message || 'Provider error';
+  const error = new Error(message);
+  (error as any).status = status;
+  throw error;
+};
+
+export const createCardSession = async () => {
+  try {
+    const resp = await axios.post(
+      `${baseUrl}/v2/payments`,
+      {
+        mode: 'API',
+        paymentMethod: { type: 'CARD' },
+        autoConfirm: false,
+      },
+      buildAuth()
+    );
+    return resp.data;
+  } catch (err: any) {
+    handleError(err);
+  }
+};
+
+export const confirmCardSession = async (
+  id: string,
+  encryptedCard: string,
+  paymentMethodOptions?: any
+) => {
+  try {
+    const resp = await axios.post(
+      `${baseUrl}/v2/payments/${id}/confirm`,
+      {
+        paymentMethod: { type: 'CARD', encryptedCard },
+        paymentMethodOptions,
+      },
+      buildAuth()
+    );
+    return resp.data;
+  } catch (err: any) {
+    handleError(err);
+  }
+};
+
+export default { createCardSession, confirmCardSession };

--- a/test/cardSession.test.ts
+++ b/test/cardSession.test.ts
@@ -1,0 +1,70 @@
+process.env.JWT_SECRET = 'test';
+process.env.PAYMENT_API_URL = 'https://provider.test';
+process.env.PAYMENT_API_KEY = 'key';
+process.env.PAYMENT_API_SECRET = 'secret';
+
+import test, { mock } from 'node:test';
+import assert from 'node:assert/strict';
+import express from 'express';
+import request from 'supertest';
+import axios from 'axios';
+
+import paymentRouterV2 from '../src/route/payment.v2.routes';
+
+const app = express();
+app.use(express.json());
+app.use('/v2/payments', paymentRouterV2);
+
+test('creates card session', async () => {
+  const m = mock.method(axios, 'post', async (url, body) => {
+    assert.equal(url, 'https://provider.test/v2/payments');
+    assert.equal(body.mode, 'API');
+    return { data: { id: 'sess1', encryptionKey: 'encKey' } };
+  });
+  const res = await request(app).post('/v2/payments/session').send({});
+  assert.equal(res.status, 201);
+  assert.equal(res.body.id, 'sess1');
+  assert.equal(res.body.encryptionKey, 'encKey');
+  assert.equal(m.mock.callCount(), 1);
+  m.mock.restore();
+});
+
+test('confirms card session', async () => {
+  const m = mock.method(axios, 'post', async (url, body) => {
+    assert.equal(url, 'https://provider.test/v2/payments/abc/confirm');
+    assert.equal(body.paymentMethod.encryptedCard, 'encrypted');
+    return { data: { paymentUrl: 'https://3ds.test' } };
+  });
+  const res = await request(app)
+    .post('/v2/payments/abc/confirm')
+    .send({ encryptedCard: 'encrypted' });
+  assert.equal(res.status, 200);
+  assert.equal(res.body.paymentUrl, 'https://3ds.test');
+  m.mock.restore();
+});
+
+test('handles provider error', async () => {
+  const m = mock.method(axios, 'post', async () => {
+    const err: any = new Error('fail');
+    err.response = { status: 400, data: { message: 'bad request' } };
+    throw err;
+  });
+  const res = await request(app).post('/v2/payments/session').send({});
+  assert.equal(res.status, 400);
+  assert.equal(res.body.error, 'bad request');
+  m.mock.restore();
+});
+
+test('handles confirm error', async () => {
+  const m = mock.method(axios, 'post', async () => {
+    const err: any = new Error('deny');
+    err.response = { status: 402, data: { message: 'payment required' } };
+    throw err;
+  });
+  const res = await request(app)
+    .post('/v2/payments/xyz/confirm')
+    .send({ encryptedCard: 'enc' });
+  assert.equal(res.status, 402);
+  assert.equal(res.body.error, 'payment required');
+  m.mock.restore();
+});


### PR DESCRIPTION
## Summary
- add card session and confirmation routes
- implement card payment controller and service
- load payment API configuration and cover with tests

## Testing
- `bash -O globstar -c "node --test -r ts-node/register test/cardSession.test.ts"`


------
https://chatgpt.com/codex/tasks/task_e_68a6d13a8080832882ed0ffb6134aaf6