### PR TITLE
feat: update card session redirect and confirm payload

### DIFF
--- a/src/service/card.service.ts
+++ b/src/service/card.service.ts
@@ -29,11 +29,9 @@ export const createCardSession = async () => {
         mode: 'API',
         paymentMethod: { type: 'CARD' },
         autoConfirm: false,
-        redirectUrl: {
-          success: `${base}/payment-success`,
-          failure: `${base}/payment-failure`,
-          expired: `${base}/payment-expired`,
-        },
+        successReturnUrl: `${base}/payment-success`,
+        failureReturnUrl: `${base}/payment-failure`,
+        expirationReturnUrl: `${base}/payment-expired`,
       },
       buildAuth()
     );
@@ -52,7 +50,7 @@ export const confirmCardSession = async (
     const resp = await axios.post(
       `${baseUrl}/v2/payments/${id}/confirm`,
       {
-        paymentMethod: { type: 'CARD', encryptedCard },
+        paymentMethod: { type: 'CARD', card: { encryptedCard } },
         paymentMethodOptions,
       },
       buildAuth()

--- a/test/cardSession.test.ts
+++ b/test/cardSession.test.ts
@@ -21,15 +21,15 @@ test('creates card session', async () => {
     assert.equal(url, 'https://provider.test/v2/payments');
     assert.equal(body.mode, 'API');
     assert.equal(
-      body.redirectUrl.success,
+      body.successReturnUrl,
       'https://merchant.test/payment-success'
     );
     assert.equal(
-      body.redirectUrl.failure,
+      body.failureReturnUrl,
       'https://merchant.test/payment-failure'
     );
     assert.equal(
-      body.redirectUrl.expired,
+      body.expirationReturnUrl,
       'https://merchant.test/payment-expired'
     );
     return { data: { id: 'sess1', encryptionKey: 'encKey' } };
@@ -57,7 +57,10 @@ test('gets payment detail', async () => {
 test('confirms card session', async () => {
   const m = mock.method(axios, 'post', async (url, body) => {
     assert.equal(url, 'https://provider.test/v2/payments/abc/confirm');
-    assert.equal(body.paymentMethod.encryptedCard, 'encrypted');
+    assert.equal(
+      body.paymentMethod.card.encryptedCard,
+      'encrypted'
+    );
     return { data: { paymentUrl: 'https://3ds.test' } };
   });
   const res = await request(app)


### PR DESCRIPTION
## Summary
- rename card session redirect fields to successReturnUrl, failureReturnUrl and expirationReturnUrl
- wrap encryptedCard in card object during session confirmation
- adjust tests for new payload structure

## Testing
- `node --test -r ts-node/register test/cardSession.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a6de72f8b88328986bbc92c4fa4da8