### PR TITLE
feat: add validation for card confirmation

### DIFF
--- a/src/route/payment.v2.routes.ts
+++ b/src/route/payment.v2.routes.ts
@@ -140,7 +140,12 @@ paymentRouterV2.post(
     cardController.createCardSession
 );
 
-paymentRouterV2.post('/:id/confirm', cardController.confirmCardSession);
+paymentRouterV2.post(
+    '/:id/confirm',
+    ...validator.confirmCardSessionValidation,
+    validator.handleValidationErrors,
+    cardController.confirmCardSession
+);
 
 paymentRouterV2.get('/:id', cardController.getPayment);
 

--- a/src/validation/validation.ts
+++ b/src/validation/validation.ts
@@ -121,6 +121,38 @@ const checkAccountValidation = [
         .withMessage('Account number is required and must be a valid number.'),
 ];
 
+// Validation rules for confirming a card session
+const confirmCardSessionValidation = [
+    param('id')
+        .isString()
+        .withMessage('Payment ID must be a string'),
+
+    body('encryptedCard')
+        .isString()
+        .isLength({ min: 1 })
+        .withMessage('encryptedCard is required and must be a non-empty string'),
+
+    body('paymentMethodOptions')
+        .optional()
+        .isObject()
+        .withMessage('paymentMethodOptions must be an object')
+        .custom(value => {
+            if (value.card && typeof value.card !== 'object') {
+                throw new Error('paymentMethodOptions.card must be an object');
+            }
+            if (value.card) {
+                const { captureMethod, threeDsMethod } = value.card;
+                if (captureMethod !== undefined && typeof captureMethod !== 'string') {
+                    throw new Error('paymentMethodOptions.card.captureMethod must be a string');
+                }
+                if (threeDsMethod !== undefined && typeof threeDsMethod !== 'string') {
+                    throw new Error('paymentMethodOptions.card.threeDsMethod must be a string');
+                }
+            }
+            return true;
+        }),
+];
+
 
 
 
@@ -131,7 +163,8 @@ const validation = {
     initiateDisbursementValidation,
     getDisbursementStatusValidation,
     checkAccountValidation,
-    createCardSessionValidation
+    createCardSessionValidation,
+    confirmCardSessionValidation
 };
 
 export default validation;


### PR DESCRIPTION
## Summary
- add express-validator middleware for confirming card sessions
- apply new validation to POST /v2/payments/:id/confirm

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6eeff71f083289b3f372a5bac3e65