### PR TITLE
Use frontend base URL for card redirects

### DIFF
--- a/docs/services/payment.md
+++ b/docs/services/payment.md
@@ -17,7 +17,7 @@ Endpoints served under `/api/v1/payment`.
 - Custom provider services (Hilogate, OY, GIDI, etc.).
 
 ## Environment Variables
-- General: `BASE_URL`, `CALLBACK_URL`, `CALLBACK_URL_FINISH`, `FORCE_PROVIDER`.
+- General: `BASE_URL`, `FRONTEND_BASE_URL`, `CALLBACK_URL`, `CALLBACK_URL_FINISH`, `FORCE_PROVIDER`.
 - Callback worker: `CALLBACK_WORKER_INTERVAL_MS`, `CALLBACK_WORKER_MAX_ATTEMPTS`, `CALLBACK_WORKER_BATCH_SIZE`.
 - Netz configuration: `NETZ_URL`, `NETZ_PARTNER_ID`, `NETZ_PRIVATE_KEY`, `NETZ_CLIENT_SECRET`.
 - Brevo email: `BREVO_URL`, `BREVO_API_KEY`.

--- a/readme.md
+++ b/readme.md
@@ -4,6 +4,10 @@ Backend for the Launcx payment aggregator.
 
 See [docs/services](docs/services) for service-specific endpoints, dependencies, and environment variables.
 
+## Environment Variables
+
+Set `FRONTEND_BASE_URL` to the publicly accessible URL of the frontend site. It is used when creating card payment sessions to build redirect links such as `/payment-success`, `/payment-failure`, and `/payment-expired`.
+
 ## Reconcile Partner Balances
 
 Run `npm run reconcile-balances` after setting database environment variables to recompute client balances.

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,8 +13,9 @@ export const config = {
   api: {
     // Base URL with port, used to build callbacks and checkout URLs
     baseUrl: process.env.BASE_URL || `http://localhost:${PORT}`,
+    frontendBaseUrl: process.env.FRONTEND_BASE_URL || '',
     forceProvider: process.env.FORCE_PROVIDER?.trim().toLowerCase() || null,
-      jwtSecret,
+    jwtSecret,
     // Prefix for Swagger server (will point to API v1)
     swaggerUrl:
       process.env.SWAGGER_URL || `http://localhost:${PORT}/api/v1`,

--- a/src/service/card.service.ts
+++ b/src/service/card.service.ts
@@ -25,8 +25,10 @@ export const createCardSession = async (
   order: any
 ) => {
   try {
-    const redirectBase =
-      process.env.CARD_REDIRECT_BASE_URL || config.api.baseUrl || '';
+    const redirectBase = config.api.frontendBaseUrl;
+    if (!redirectBase) {
+      throw new Error('FRONTEND_BASE_URL environment variable is required');
+    }
     const base = redirectBase.replace(/\/$/, '');
     const resp = await axios.post(
       `${baseUrl}/v2/payments`,

--- a/test/cardSession.test.ts
+++ b/test/cardSession.test.ts
@@ -2,7 +2,7 @@ process.env.JWT_SECRET = 'test';
 process.env.PAYMENT_API_URL = 'https://provider.test';
 process.env.PAYMENT_API_KEY = 'key';
 process.env.PAYMENT_API_SECRET = 'secret';
-process.env.CARD_REDIRECT_BASE_URL = 'https://merchant.test';
+process.env.FRONTEND_BASE_URL = 'https://merchant.test/';
 
 import test, { mock } from 'node:test';
 import assert from 'node:assert/strict';


### PR DESCRIPTION
## Summary
- require `FRONTEND_BASE_URL` for card session redirects and drop backend fallback
- expose `frontendBaseUrl` in config and document the env variable

## Testing
- `node --test -r ts-node/register test/cardSession.test.ts`
- `node --test -r ts-node/register $(find test -name "*.test.ts" -print)` *(fails: /workspace/launcxbaru/test/settings.routes.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f0be4d4883288a838e2db870e523