### PR TITLE
Log card transactions and persist provider responses

### DIFF
--- a/src/controller/card.controller.ts
+++ b/src/controller/card.controller.ts
@@ -31,6 +31,13 @@ export const createCardSession = async (req: Request, res: Response) => {
     const customer = req.body?.customer;
     const orderInfo = req.body?.orderInformation ?? req.body?.order ?? undefined;
 
+    const buyerId = req.body?.buyerId;
+    const subMerchantId = req.body?.subMerchantId;
+    const playerId = req.body?.playerId;
+    if (!buyerId || !subMerchantId) {
+      return res.status(400).json({ error: 'Missing buyerId or subMerchantId' });
+    }
+
     const session = await cardService.createCardSession(
       amountValue,
       currency,
@@ -42,7 +49,8 @@ export const createCardSession = async (req: Request, res: Response) => {
         metadata: req.body?.metadata,
         paymentType: req.body?.paymentType, // service akan default 'SINGLE' jika undefined
         clientReferenceId: req.body?.clientReferenceId,
-      }
+      },
+      { buyerId, subMerchantId, playerId }
     );
 
     // Pastikan FE selalu dapat { id, encryptionKey }

--- a/test/cardSession.test.ts
+++ b/test/cardSession.test.ts
@@ -13,11 +13,17 @@ delete process.env.npm_config_proxy;
 
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import nock from 'nock';
+const nock = require('nock');
 import express from 'express';
 import request from 'supertest';
 
 import paymentRouterV2 from '../src/route/payment.v2.routes';
+import { prisma } from '../src/core/prisma';
+
+(prisma as any).transaction_request = { create: async () => ({ id: 'req1' }) };
+(prisma as any).transaction_response = { create: async () => ({}) };
+(prisma as any).order = { create: async () => ({}), update: async () => ({}) };
+(prisma as any).sub_merchant = { findUnique: async () => ({ merchantId: 'm1' }) };
 
 nock.disableNetConnect();
 nock.enableNetConnect('127.0.0.1');
@@ -28,22 +34,23 @@ app.use('/v2/payments', paymentRouterV2);
 
 test('creates card session', async () => {
   const payload = {
-    amount: 1000,
-    currency: 'IDR',
+    amount: { value: 1000, currency: 'IDR' },
     customer: { email: 'john@example.com' },
-    order: { referenceId: 'order1' },
+    orderInformation: { referenceId: 'order1' },
+    buyerId: 'b1',
+    subMerchantId: 's1',
   };
 
   nock('https://provider.test')
     .post('/v2/payments', body => {
       assert.equal(body.mode, 'API');
-      assert.equal(body.amount, payload.amount);
-      assert.equal(body.currency, payload.currency);
+      assert.equal(body.amount.value, 1000);
+      assert.equal(body.amount.currency, 'IDR');
       assert.equal(body.customer.email, payload.customer.email);
-      assert.equal(body.order.referenceId, payload.order.referenceId);
-      assert.equal(body.successReturnUrl, 'https://merchant.test/payment-success');
-      assert.equal(body.failureReturnUrl, 'https://merchant.test/payment-failure');
-      assert.equal(body.expirationReturnUrl, 'https://merchant.test/payment-expired');
+      assert.equal(body.orderInformation.referenceId, payload.orderInformation.referenceId);
+      assert.equal(body.redirectUrl.successReturnUrl, 'https://merchant.test/payment-success');
+      assert.equal(body.redirectUrl.failureReturnUrl, 'https://merchant.test/payment-failure');
+      assert.equal(body.redirectUrl.expirationReturnUrl, 'https://merchant.test/payment-expired');
       return true;
     })
     .reply(201, { id: 'sess1', encryptionKey: 'encKey' });
@@ -88,7 +95,7 @@ test('handles provider error on session creation', async () => {
     .post('/v2/payments')
     .reply(400, { message: 'bad request' });
 
-  const payload = { amount: 1000, currency: 'IDR' };
+  const payload = { amount: { value: 1000, currency: 'IDR' }, buyerId: 'b1', subMerchantId: 's1' };
   const res = await request(app).post('/v2/payments/session').send(payload);
 
   assert.equal(res.status, 400);


### PR DESCRIPTION
## Summary
- store card transaction requests and responses in Prisma
- persist card orders and update status on confirmation
- capture buyer and sub-merchant IDs in card session API

## Testing
- `node --test -r ts-node/register test/cardSession.test.ts` *(fails: expected 402 but got 500)*

------
https://chatgpt.com/codex/tasks/task_e_68a7578bf2e8832891c24fcfdbe93bab