### PR TITLE
feat: add manual settlement batches from admin

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -17,6 +17,7 @@ import adminClientUserRoutes from './route/admin/clientUser.routes';
 import adminTotpRoutes from './route/admin/totp.routes';
 import adminLogRoutes from './route/admin/log.routes';
 import adminIpWhitelistRoutes from './route/admin/ipWhitelist.routes';
+import adminSettlementRoutes from './route/admin/settlement.routes';
 
 import usersRoutes from './route/users.routes';
 
@@ -147,12 +148,13 @@ app.use('/api/v1/admin/clients/:clientId/users', adminClientUserRoutes);
 
 app.use('/api/v1/admin/settings', authMiddleware, settingsRoutes);
 
-app.use('/api/v1/admin/2fa', adminTotpRoutes);
-app.use('/api/v1/admin/logs', adminLogRoutes);
-app.use('/api/v1/admin/ip-whitelist', adminIpWhitelistRoutes);
+  app.use('/api/v1/admin/2fa', adminTotpRoutes);
+  app.use('/api/v1/admin/logs', adminLogRoutes);
+  app.use('/api/v1/admin/ip-whitelist', adminIpWhitelistRoutes);
+  app.use('/api/v1/admin/settlement', adminSettlementRoutes);
 
-/* ========== 4. PARTNER-CLIENT (login/register + dashboard + withdraw) ========== */
-app.use('/api/v1/client', clientWebRoutes);
+  /* ========== 4. PARTNER-CLIENT (login/register + dashboard + withdraw) ========== */
+  app.use('/api/v1/client', clientWebRoutes);
 
 
 /* ========== 5. PROTECTED – MERCHANT DASHBOARD ========== */

--- a/src/controller/admin/settlement.controller.ts
+++ b/src/controller/admin/settlement.controller.ts
@@ -1,0 +1,18 @@
+import { Response } from 'express'
+import { runManualSettlement } from '../../cron/settlement'
+import { AuthRequest } from '../../middleware/auth'
+import { logAdminAction } from '../../util/adminLog'
+
+export async function manualSettlement(req: AuthRequest, res: Response) {
+  const batches =
+    typeof req.body?.batches === 'number' && req.body.batches > 0
+      ? req.body.batches
+      : 1
+
+  const result = await runManualSettlement(batches)
+  if (req.userId) {
+    await logAdminAction(req.userId, 'manualSettlement', null, { batches })
+  }
+  res.json({ data: result })
+}
+

--- a/src/cron/settlement.ts
+++ b/src/cron/settlement.ts
@@ -335,3 +335,21 @@ export function restartSettlementChecker(expr: string) {
   settlementTask?.destroy();
   settlementTask = createTask(expr || '0 16 * * *');
 }
+
+export async function runManualSettlement(batches = 1) {
+  cutoffTime = new Date();
+  lastCreatedAt = null;
+  lastId = null;
+
+  let settledOrders = 0;
+  let netAmount = 0;
+
+  for (let i = 0; i < batches; i++) {
+    const { settledCount, netAmount: na } = await processBatchOnce();
+    if (!settledCount) break;
+    settledOrders += settledCount;
+    netAmount += na;
+  }
+
+  return { settledOrders, netAmount };
+}

--- a/src/route/admin/settlement.routes.ts
+++ b/src/route/admin/settlement.routes.ts
@@ -1,0 +1,12 @@
+import { Router } from 'express'
+import { requireAdminAuth } from '../../middleware/auth'
+import { manualSettlement } from '../../controller/admin/settlement.controller'
+
+const router = Router()
+
+router.use(requireAdminAuth)
+
+router.post('/', manualSettlement)
+
+export default router
+

--- a/test/adminSettlement.routes.test.ts
+++ b/test/adminSettlement.routes.test.ts
@@ -1,0 +1,29 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import express from 'express'
+import request from 'supertest'
+
+// Patch runManualSettlement before loading controller
+const settlement = require('../src/cron/settlement')
+let lastBatches: number | null = null
+settlement.runManualSettlement = async (batches: number) => {
+  lastBatches = batches
+  return { settledOrders: 0, netAmount: 0 }
+}
+
+const { manualSettlement } = require('../src/controller/admin/settlement.controller')
+
+const app = express()
+app.use(express.json())
+app.post('/settlement', (req, res) => {
+  ;(req as any).userId = 'admin1'
+  manualSettlement(req as any, res)
+})
+
+test('manual settlement passes batch count', async () => {
+  lastBatches = null
+  const res = await request(app).post('/settlement').send({ batches: 5 })
+  assert.equal(res.status, 200)
+  assert.equal(lastBatches, 5)
+})
+


### PR DESCRIPTION
## Summary
- allow manual settlement batches
- expose admin endpoint to trigger manual settlement
- cover manual settlement with a route test

## Testing
- `npm test` *(fails: Cannot find module 'ts-node/register')*


------
https://chatgpt.com/codex/tasks/task_e_68a80a2137e88328bc42211bd2137c37