### PR TITLE
feat(frontend): add manual settlement page

### DIFF
--- a/frontend/src/pages/admin/settlement.tsx
+++ b/frontend/src/pages/admin/settlement.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import { useState } from 'react'
+import api from '@/lib/api'
+import { useRequireAuth } from '@/hooks/useAuth'
+
+interface Result {
+  settledOrders: number
+  netAmount: number
+}
+
+export default function ManualSettlementPage() {
+  useRequireAuth()
+  const [batches, setBatches] = useState('1')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [result, setResult] = useState<Result | null>(null)
+
+  const run = async () => {
+    setLoading(true)
+    setError('')
+    setResult(null)
+    try {
+      const res = await api.post<{ data: Result }>('/admin/settlement', {
+        batches: Number(batches) || 1,
+      })
+      setResult(res.data.data)
+    } catch (e: any) {
+      setError(e.response?.data?.error || 'Failed to run settlement')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="p-8 max-w-md">
+      <h1 className="text-3xl font-bold mb-4">Manual Settlement</h1>
+      {error && <div className="text-red-600 mb-3">{error}</div>}
+      <div className="flex items-center space-x-2 mb-4">
+        <input
+          type="number"
+          min={1}
+          value={batches}
+          onChange={e => setBatches(e.target.value)}
+          className="border px-3 py-2 rounded w-24"
+        />
+        <button
+          onClick={run}
+          disabled={loading}
+          className="px-4 py-2 bg-blue-600 text-white rounded"
+        >
+          {loading ? 'Running…' : 'Run'}
+        </button>
+      </div>
+      {result && (
+        <div className="mt-4">
+          <p>Settled Orders: {result.settledOrders}</p>
+          <p>
+            Net Amount:{' '}
+            {result.netAmount.toLocaleString('id-ID', {
+              style: 'currency',
+              currency: 'IDR',
+            })}
+          </p>
+        </div>
+      )}
+    </div>
+  )
+}
+

--- a/src/app.ts
+++ b/src/app.ts
@@ -17,6 +17,7 @@ import adminClientUserRoutes from './route/admin/clientUser.routes';
 import adminTotpRoutes from './route/admin/totp.routes';
 import adminLogRoutes from './route/admin/log.routes';
 import adminIpWhitelistRoutes from './route/admin/ipWhitelist.routes';
+import adminSettlementRoutes from './route/admin/settlement.routes';
 
 import usersRoutes from './route/users.routes';
 
@@ -147,12 +148,13 @@ app.use('/api/v1/admin/clients/:clientId/users', adminClientUserRoutes);
 
 app.use('/api/v1/admin/settings', authMiddleware, settingsRoutes);
 
-app.use('/api/v1/admin/2fa', adminTotpRoutes);
-app.use('/api/v1/admin/logs', adminLogRoutes);
-app.use('/api/v1/admin/ip-whitelist', adminIpWhitelistRoutes);
+  app.use('/api/v1/admin/2fa', adminTotpRoutes);
+  app.use('/api/v1/admin/logs', adminLogRoutes);
+  app.use('/api/v1/admin/ip-whitelist', adminIpWhitelistRoutes);
+  app.use('/api/v1/admin/settlement', adminSettlementRoutes);
 
-/* ========== 4. PARTNER-CLIENT (login/register + dashboard + withdraw) ========== */
-app.use('/api/v1/client', clientWebRoutes);
+  /* ========== 4. PARTNER-CLIENT (login/register + dashboard + withdraw) ========== */
+  app.use('/api/v1/client', clientWebRoutes);
 
 
 /* ========== 5. PROTECTED – MERCHANT DASHBOARD ========== */

--- a/src/controller/admin/settlement.controller.ts
+++ b/src/controller/admin/settlement.controller.ts
@@ -1,0 +1,18 @@
+import { Response } from 'express'
+import { runManualSettlement } from '../../cron/settlement'
+import { AuthRequest } from '../../middleware/auth'
+import { logAdminAction } from '../../util/adminLog'
+
+export async function manualSettlement(req: AuthRequest, res: Response) {
+  const batches =
+    typeof req.body?.batches === 'number' && req.body.batches > 0
+      ? req.body.batches
+      : 1
+
+  const result = await runManualSettlement(batches)
+  if (req.userId) {
+    await logAdminAction(req.userId, 'manualSettlement', null, { batches })
+  }
+  res.json({ data: result })
+}
+

--- a/src/cron/settlement.ts
+++ b/src/cron/settlement.ts
@@ -335,3 +335,21 @@ export function restartSettlementChecker(expr: string) {
   settlementTask?.destroy();
   settlementTask = createTask(expr || '0 16 * * *');
 }
+
+export async function runManualSettlement(batches = 1) {
+  cutoffTime = new Date();
+  lastCreatedAt = null;
+  lastId = null;
+
+  let settledOrders = 0;
+  let netAmount = 0;
+
+  for (let i = 0; i < batches; i++) {
+    const { settledCount, netAmount: na } = await processBatchOnce();
+    if (!settledCount) break;
+    settledOrders += settledCount;
+    netAmount += na;
+  }
+
+  return { settledOrders, netAmount };
+}

--- a/src/route/admin/settlement.routes.ts
+++ b/src/route/admin/settlement.routes.ts
@@ -1,0 +1,12 @@
+import { Router } from 'express'
+import { requireAdminAuth } from '../../middleware/auth'
+import { manualSettlement } from '../../controller/admin/settlement.controller'
+
+const router = Router()
+
+router.use(requireAdminAuth)
+
+router.post('/', manualSettlement)
+
+export default router
+

--- a/test/adminSettlement.routes.test.ts
+++ b/test/adminSettlement.routes.test.ts
@@ -1,0 +1,29 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import express from 'express'
+import request from 'supertest'
+
+// Patch runManualSettlement before loading controller
+const settlement = require('../src/cron/settlement')
+let lastBatches: number | null = null
+settlement.runManualSettlement = async (batches: number) => {
+  lastBatches = batches
+  return { settledOrders: 0, netAmount: 0 }
+}
+
+const { manualSettlement } = require('../src/controller/admin/settlement.controller')
+
+const app = express()
+app.use(express.json())
+app.post('/settlement', (req, res) => {
+  ;(req as any).userId = 'admin1'
+  manualSettlement(req as any, res)
+})
+
+test('manual settlement passes batch count', async () => {
+  lastBatches = null
+  const res = await request(app).post('/settlement').send({ batches: 5 })
+  assert.equal(res.status, 200)
+  assert.equal(lastBatches, 5)
+})
+


### PR DESCRIPTION
## Summary
- add admin page to trigger manual settlement with custom batch count

## Testing
- `node --test -r ts-node/register $(find test -name "*.test.ts")` *(fails: test failed in settings.routes.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68a80a2137e88328bc42211bd2137c37