### PR TITLE
Reset settlement state before manual or queued runs

### DIFF
--- a/src/controller/admin/settlement.controller.ts
+++ b/src/controller/admin/settlement.controller.ts
@@ -1,10 +1,11 @@
 import { Response } from 'express'
-import { runManualSettlement } from '../../cron/settlement'
+import { runManualSettlement, resetSettlementState } from '../../cron/settlement'
 import { AuthRequest } from '../../middleware/auth'
 import { logAdminAction } from '../../util/adminLog'
 import { startSettlementJob, getSettlementJob } from '../../worker/settlementJob'
 
 export async function manualSettlement(req: AuthRequest, res: Response) {
+  resetSettlementState()
   const result = await runManualSettlement()
   if (req.userId) {
     await logAdminAction(req.userId, 'manualSettlement', null, result)
@@ -13,6 +14,7 @@ export async function manualSettlement(req: AuthRequest, res: Response) {
 }
 
 export async function startSettlement(req: AuthRequest, res: Response) {
+  resetSettlementState()
   const jobId = startSettlementJob()
   if (req.userId) {
     await logAdminAction(req.userId, 'manualSettlementStart', null, { jobId })


### PR DESCRIPTION
## Summary
- add resetSettlementState to clear cursor and restart cron using saved expression
- trigger reset before manual settlement and queued job execution

## Testing
- `npm test` *(fails: Could not find '/workspace/launcxbaru/test/**/*.test.ts')*
- `npm run build` *(fails: Module '@prisma/client' has no exported member 'DisbursementStatus' and other TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a82dd5d32c8328b55b548ea8b686c9