### PR TITLE
Move card payments API to v1

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -131,9 +131,9 @@ app.use('/api/v1/auth', authRoutes);       // login / register for admins and cl
 app.use('/api/v1', ewalletRoutes);         // public e-wallet endpoints
 
 /* ========== 2. PROTECTED – API-KEY (SERVER-TO-SERVER) ========== */
-app.use('/api/v1/payments', apiKeyAuth, paymentRouter);
-app.use('/api/v2/payments', paymentRouterV2);
-app.use('/api/v2/payments', pivotCallbackRouter);
+app.use('/api/v1/payments/legacy', apiKeyAuth, paymentRouter);
+app.use('/api/v1/payments', paymentRouterV2);
+app.use('/api/v1/payments', pivotCallbackRouter);
 
 // app.use('/api/v1/disbursements', apiKeyAuth, disbursementRouter);
 app.use('/api/v1', simulateRoutes);

--- a/test/pivotCallback.routes.test.ts
+++ b/test/pivotCallback.routes.test.ts
@@ -10,10 +10,10 @@ import pivotCallbackRouter from '../src/route/payment.callback.routes';
 test('pivot callback accepts JSON and returns ok', async () => {
   const app = express();
   app.use(express.json());
-  app.use('/v2/payments', pivotCallbackRouter);
+  app.use('/v1/payments', pivotCallbackRouter);
 
   const res = await request(app)
-    .post('/v2/payments/callback/pivot')
+    .post('/v1/payments/callback/pivot')
     .send({
       event: 'PAYMENT.PAID',
       data: { id: 'pay_123', amount: { value: 1000, currency: 'IDR' }, status: 'PAID' }


### PR DESCRIPTION
## Summary
- expose card payments router under `/api/v1/payments`
- relocate legacy payment router to `/api/v1/payments/legacy`
- update tests for new card payments base path

## Testing
- `node --test -r ts-node/register $(find test -name '*.test.ts')` *(fails: test failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b8d48c808328b1cbafd14e577867