### PR TITLE
Remove v2 prefix from frontend payment API endpoints

### DIFF
--- a/frontend/src/pages/checkout.tsx
+++ b/frontend/src/pages/checkout.tsx
@@ -40,7 +40,7 @@ export default function CheckoutPage() {
 
  // SELALU buat session baru (fresh) setiap dipanggil
 const ensureSession = async () => {
-  const res = await axios.post(`${API_URL}/v2/payments/session`, {
+  const res = await axios.post(`${API_URL}/payments/session`, {
     amount: { value: Number(amount), currency: 'IDR' },
   });
 
@@ -111,7 +111,7 @@ const handleSubmit = async (e: React.FormEvent) => {
     const encryptedCard = await encryptHybrid(JSON.stringify(payload), base64Spki);
 
     // 5) Confirm
-    const res = await axios.post(`${API_URL}/v2/payments/${id}/confirm`, {
+    const res = await axios.post(`${API_URL}/payments/${id}/confirm`, {
       encryptedCard,
       paymentMethodOptions: {
         card: { captureMethod, threeDsMethod },

--- a/frontend/src/pages/payment-expired.tsx
+++ b/frontend/src/pages/payment-expired.tsx
@@ -14,7 +14,7 @@ export default function PaymentExpired() {
   useEffect(() => {
     if (id) {
       axios
-        .get(`${API_URL}/v2/payments/${id}`)
+        .get(`${API_URL}/payments/${id}`)
         .then(res => setDetails(res.data))
         .catch(() => {})
     }

--- a/frontend/src/pages/payment-failure.tsx
+++ b/frontend/src/pages/payment-failure.tsx
@@ -14,7 +14,7 @@ export default function PaymentFailure() {
   useEffect(() => {
     if (id) {
       axios
-        .get(`${API_URL}/v2/payments/${id}`)
+        .get(`${API_URL}/payments/${id}`)
         .then(res => setDetails(res.data))
         .catch(() => {})
     }

--- a/frontend/src/pages/payment-success.tsx
+++ b/frontend/src/pages/payment-success.tsx
@@ -14,7 +14,7 @@ export default function PaymentSuccess() {
   useEffect(() => {
     if (id) {
       axios
-        .get(`${API_URL}/v2/payments/${id}`)
+        .get(`${API_URL}/payments/${id}`)
         .then(res => setDetails(res.data))
         .catch(() => {})
     }


### PR DESCRIPTION
## Summary
- point checkout page to new `/payments` session and confirm endpoints
- update payment status pages to fetch payment details without the `/v2` prefix

## Testing
- `npm test`
- `cd frontend && npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68a8ba15fde08328957ae0a0ee75fdb1