### PR TITLE
feat: handle eventType in pivot callback

### DIFF
--- a/src/controller/pivotCallback.controller.ts
+++ b/src/controller/pivotCallback.controller.ts
@@ -60,6 +60,7 @@ function extractEvent(body: any): string | undefined {
   return (
     (typeof body?.event === 'string' && body.event) ||
     (typeof body?.type === 'string' && body.type) ||
+    (typeof body?.eventType === 'string' && body.eventType) ||
     undefined
   );
 }

--- a/src/route/payment.callback.routes.ts
+++ b/src/route/payment.callback.routes.ts
@@ -40,9 +40,12 @@ function debugBody(req: Request, _res: Response, next: NextFunction) {
  *         application/json:
  *           schema:
  *             type: object
- *             required: [event, data]
+ *             required: [data]
  *             properties:
  *               event:
+ *                 type: string
+ *                 enum: [PAYMENT.PROCESSING, PAYMENT.PAID, CHARGE.SUCCESS, PAYMENT.CANCELLED]
+ *               eventType:
  *                 type: string
  *                 enum: [PAYMENT.PROCESSING, PAYMENT.PAID, CHARGE.SUCCESS, PAYMENT.CANCELLED]
  *               data:
@@ -58,7 +61,7 @@ function debugBody(req: Request, _res: Response, next: NextFunction) {
  *                     description: Alternative ID when `id` is absent
  *                     example: psess_123
  *           example:
- *             event: PAYMENT.PAID
+ *             eventType: PAYMENT.PAID
  *             data:
  *               paymentSessionId: psess_123
  *               amount:

--- a/src/types/pivot-callback.ts
+++ b/src/types/pivot-callback.ts
@@ -46,6 +46,8 @@ export interface PivotPaymentData {
 }
 
 export interface PivotCallbackBody {
-  event: PivotCallbackEvent;
+  event?: PivotCallbackEvent;
+  eventType?: PivotCallbackEvent;
+  type?: PivotCallbackEvent;
   data: PivotPaymentData;
 }

--- a/test/pivotCallback.routes.test.ts
+++ b/test/pivotCallback.routes.test.ts
@@ -38,3 +38,19 @@ test('pivot callback handles data.paymentSessionId', async () => {
   assert.equal(res.status, 200);
   assert.deepEqual(res.body, { ok: true });
 });
+
+test('pivot callback accepts eventType field', async () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/v1/payments', pivotCallbackRouter);
+
+  const res = await request(app)
+    .post('/v1/payments/callback/pivot')
+    .send({
+      eventType: 'PAYMENT.PAID',
+      data: { id: 'pay_456', amount: { value: 2000, currency: 'IDR' }, status: 'PAID' }
+    });
+
+  assert.equal(res.status, 200);
+  assert.deepEqual(res.body, { ok: true });
+});


### PR DESCRIPTION
## Summary
- extend `extractEvent` to read `eventType`
- document `eventType` in Pivot callback route
- test callback when `eventType` is provided

## Testing
- `node --test -r ts-node/register test/pivotCallback.routes.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a8dc0060c88328ab86a0866611a9dd