### PR TITLE
Include Accept header in pivot client requests

### DIFF
--- a/src/service/card.service.ts
+++ b/src/service/card.service.ts
@@ -58,7 +58,11 @@ const requestNewToken = async (): Promise<string> => {
 const refreshPivotToken = async (): Promise<string> => requestNewToken();
 
 const withBearer = (token: string) => ({
-  headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+  headers: {
+    Authorization: `Bearer ${token}`,
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+  },
   timeout: 20000,
 });
 


### PR DESCRIPTION
## Summary
- ensure all pivot requests specify JSON Accept headers via withBearer

## Testing
- `npm test` *(fails: Could not find '/workspace/launcxbaru/test/**/*.test.ts')*

------
https://chatgpt.com/codex/tasks/task_e_68a8de1356648328aea1a1ce6026dab8