### PR TITLE
feat: fall back to chargeDetails paymentSessionId

### DIFF
--- a/src/controller/pivotCallback.controller.ts
+++ b/src/controller/pivotCallback.controller.ts
@@ -65,15 +65,25 @@ function extractEvent(body: any): string | undefined {
   );
 }
 function extractPaymentId(body: any): string | undefined {
-  return (
+  const topLevel =
     body?.data?.id ??
     body?.data?.paymentSessionId ??
     body?.id ??
     body?.paymentId ??
     body?.paymentSessionId ??
     body?.payment?.id ??
-    body?.charge?.paymentSessionId
-  );
+    body?.charge?.paymentSessionId;
+
+  if (topLevel) return topLevel;
+
+  const chargeDetails = body?.data?.chargeDetails;
+  if (Array.isArray(chargeDetails)) {
+    for (const ch of chargeDetails) {
+      const sid = ch?.paymentSessionId;
+      if (typeof sid === 'string' && sid) return sid;
+    }
+  }
+  return undefined;
 }
 
 // --- Normalizers (unchanged logic, just types defensive) ---

--- a/test/pivotCallback.routes.test.ts
+++ b/test/pivotCallback.routes.test.ts
@@ -39,6 +39,26 @@ test('pivot callback handles data.paymentSessionId', async () => {
   assert.deepEqual(res.body, { ok: true });
 });
 
+test('pivot callback handles chargeDetails paymentSessionId', async () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/v1/payments', pivotCallbackRouter);
+
+  const res = await request(app)
+    .post('/v1/payments/callback/pivot')
+    .send({
+      event: 'PAYMENT.PAID',
+      data: {
+        chargeDetails: [{ paymentSessionId: 'psess_789' }],
+        amount: { value: 1000, currency: 'IDR' },
+        status: 'PAID'
+      }
+    });
+
+  assert.equal(res.status, 200);
+  assert.deepEqual(res.body, { ok: true });
+});
+
 test('pivot callback accepts eventType field', async () => {
   const app = express();
   app.use(express.json());


### PR DESCRIPTION
## Summary
- extend pivot callback ID extraction to search chargeDetails for paymentSessionId
- test callback handling when only chargeDetails[0].paymentSessionId is provided

## Testing
- `node --test -r ts-node/register test/pivotCallback.routes.test.ts`
- `node --test -r ts-node/register $(find test -name "*.test.ts")` *(fails: 5 failing tests in settings.routes.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68a8dece028c832881a3cc1e003f5e77