### PR TITLE
Handle root-level chargeDetails in Pivot callback

### DIFF
--- a/src/controller/pivotCallback.controller.ts
+++ b/src/controller/pivotCallback.controller.ts
@@ -79,10 +79,19 @@ function extractPaymentId(body: any): string | undefined {
   const chargeDetails = body?.data?.chargeDetails;
   if (Array.isArray(chargeDetails)) {
     for (const ch of chargeDetails) {
-      const sid = ch?.paymentSessionId;
+      const sid = ch?.paymentSessionId || ch?.paymentSessionClientReferenceId;
       if (typeof sid === 'string' && sid) return sid;
     }
   }
+
+  const rootChargeDetails = body?.chargeDetails;
+  if (Array.isArray(rootChargeDetails)) {
+    for (const ch of rootChargeDetails) {
+      const sid = ch?.paymentSessionId || ch?.paymentSessionClientReferenceId;
+      if (typeof sid === 'string' && sid) return sid;
+    }
+  }
+
   return undefined;
 }
 

--- a/test/pivotCallback.routes.test.ts
+++ b/test/pivotCallback.routes.test.ts
@@ -59,6 +59,22 @@ test('pivot callback handles chargeDetails paymentSessionId', async () => {
   assert.deepEqual(res.body, { ok: true });
 });
 
+test('pivot callback handles root chargeDetails paymentSessionClientReferenceId', async () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/v1/payments', pivotCallbackRouter);
+
+  const res = await request(app)
+    .post('/v1/payments/callback/pivot')
+    .send({
+      event: 'PAYMENT.PAID',
+      chargeDetails: [{ paymentSessionClientReferenceId: 'client_ref_123' }]
+    });
+
+  assert.equal(res.status, 200);
+  assert.deepEqual(res.body, { ok: true });
+});
+
 test('pivot callback accepts eventType field', async () => {
   const app = express();
   app.use(express.json());


### PR DESCRIPTION
## Summary
- support extracting payment ID from root `chargeDetails` using `paymentSessionId` or `paymentSessionClientReferenceId`
- add test for root-level `chargeDetails` with client reference ID

## Testing
- `node --test -r ts-node/register test/pivotCallback.routes.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a8e24f38508328b17bbfccc38e6248