### PR TITLE
feat: allow configurable pivot events

### DIFF
--- a/src/controller/pivotCallback.controller.ts
+++ b/src/controller/pivotCallback.controller.ts
@@ -4,13 +4,20 @@ import { PivotCallbackBody } from '../types/pivot-callback';
 import cardService from '../service/card.service';
 
 const CALLBACK_API_KEY = process.env.PIVOT_CALLBACK_API_KEY || '';
-
-const ALLOWED_EVENTS = new Set([
+const DEFAULT_ALLOWED_EVENTS = [
   'PAYMENT.PROCESSING',
   'PAYMENT.PAID',
   'CHARGE.SUCCESS',
   'PAYMENT.CANCELLED',
-]);
+  'PAYMENT.TEST',
+];
+
+const envEvents = process.env.PIVOT_CALLBACK_ALLOWED_EVENTS
+  ?.split(',')
+  .map((e) => e.trim())
+  .filter(Boolean);
+
+const ALLOWED_EVENTS = new Set(envEvents?.length ? envEvents : DEFAULT_ALLOWED_EVENTS);
 
 function parseDateSafe(v: unknown): Date | null {
   if (v == null) return null;

--- a/src/route/payment.callback.routes.ts
+++ b/src/route/payment.callback.routes.ts
@@ -44,10 +44,10 @@ function debugBody(req: Request, _res: Response, next: NextFunction) {
  *             properties:
  *               event:
  *                 type: string
- *                 enum: [PAYMENT.PROCESSING, PAYMENT.PAID, CHARGE.SUCCESS, PAYMENT.CANCELLED]
+ *                 enum: [PAYMENT.PROCESSING, PAYMENT.PAID, CHARGE.SUCCESS, PAYMENT.CANCELLED, PAYMENT.TEST]
  *               eventType:
  *                 type: string
- *                 enum: [PAYMENT.PROCESSING, PAYMENT.PAID, CHARGE.SUCCESS, PAYMENT.CANCELLED]
+ *                 enum: [PAYMENT.PROCESSING, PAYMENT.PAID, CHARGE.SUCCESS, PAYMENT.CANCELLED, PAYMENT.TEST]
  *               data:
  *                 type: object
  *                 description: Payment Session data dari Pivot


### PR DESCRIPTION
## Summary
- allow pivot callback events to be configured via env var and add test event
- document new allowed event in swagger
- cover default and env-configured events in pivot callback tests

## Testing
- `npm test` *(fails: Could not find '/workspace/launcxbaru/test/**/*.test.ts')*
- `npm run generate`
- `node --test -r ts-node/register test/pivotCallback.routes.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a8e735b9a08328b8a0ef3cc497e75e