### PR TITLE
feat: add gidi withdrawal status query

### DIFF
--- a/docs/services/withdrawal.md
+++ b/docs/services/withdrawal.md
@@ -1,0 +1,15 @@
+# Withdrawal Service
+
+Endpoints served under `/api/v1/withdrawals`.
+
+## GIDI Status Query
+
+Pending withdrawals created via the GIDI provider are periodically rechecked using the `queryTransfer` endpoint.
+The `statusTransfer` from GIDI is mapped to internal `DisbursementStatus` values:
+
+- `Success` → `COMPLETED`
+- `Failed`  → `FAILED`
+- `Pending`, `Init`, `Timeout` → `PENDING`
+
+The job updates the corresponding `withdrawRequest` record. Transfers reported as `Failed` refund the
+withheld amount back to the partner balance.


### PR DESCRIPTION
## Summary
- support querying pending GIDI withdrawals using `queryTransfer`
- map GIDI `statusTransfer` to `DisbursementStatus` and refund on failure
- document GIDI withdrawal status query mapping

## Testing
- `npm test` *(fails: Could not find '/workspace/launcxbaru/test/**/*.test.ts')*

------
https://chatgpt.com/codex/tasks/task_e_68aae4a270c48328b5393968f5bc6c44