### PR TITLE
Handle GIDI API errors

### DIFF
--- a/src/service/gidiClient.ts
+++ b/src/service/gidiClient.ts
@@ -3,6 +3,13 @@
 import axios, { AxiosInstance } from 'axios'
 import crypto from 'crypto'
 
+export class GidiError extends Error {
+  constructor(public code: string, message: string) {
+    super(`${message} (${code})`)
+    this.name = 'GidiError'
+  }
+}
+
 export interface GidiDisbursementConfig {
   baseUrl: string
   merchantId: string
@@ -44,6 +51,9 @@ export class GidiClient {
       signature: this.signInquiry(requestId),
     }
     const { data } = await this.axiosInst.post('/Transfer/InquiryAccount', body)
+    if (data.responseCode !== 'SUCCESS') {
+      throw new GidiError(data.responseCode, data.responseMessage)
+    }
     return data.responseDetail
   }
 
@@ -89,6 +99,9 @@ export class GidiClient {
       ),
     }
     const { data } = await this.axiosInst.post('/Transfer/Bifast', body)
+    if (data.responseCode !== 'SUCCESS') {
+      throw new GidiError(data.responseCode, data.responseMessage)
+    }
     return data.responseDetail
   }
 
@@ -109,6 +122,9 @@ export class GidiClient {
       signature: this.signQuery(requestId, transactionId),
     }
     const { data } = await this.axiosInst.post('/Transfer/BifastQuery', body)
+    if (data.responseCode !== 'SUCCESS') {
+      throw new GidiError(data.responseCode, data.responseMessage)
+    }
     return data.responseDetail
   }
 }


### PR DESCRIPTION
## Summary
- throw `GidiError` when GIDI API responseCode is not SUCCESS
- surface GIDI disbursement errors in withdrawal and admin flows
- ensure admin withdraw controller returns provider error messages

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aae6d4570c832898d0e5f212cc5f4b