### PR TITLE
feat: support withdrawal reference filtering

### DIFF
--- a/docs/api/withdrawal.yaml
+++ b/docs/api/withdrawal.yaml
@@ -39,6 +39,12 @@ paths:
       summary: List all withdrawals for this client
       security:
         - clientAuth: []
+      parameters:
+        - in: query
+          name: ref
+          schema:
+            type: string
+          description: Filter by partial reference ID (case-insensitive)
       responses:
         "200":
           description: List of withdrawals

--- a/docs/services/client.md
+++ b/docs/services/client.md
@@ -17,6 +17,8 @@ Endpoints served under `/api/v1/client`.
 - `POST /withdrawals/validate-account` – validate bank account before withdrawal.
 - `POST /withdrawals` – request a withdrawal.
 - `GET /withdrawals` – list past withdrawals.
+  Optional query parameters:
+  - `ref` — filter withdrawals by partial reference ID (case-insensitive).
 - `POST /withdrawals/:id/retry` – retry a failed withdrawal.
 
 ## Dependencies

--- a/frontend/src/components/dashboard/WithdrawalHistory.tsx
+++ b/frontend/src/components/dashboard/WithdrawalHistory.tsx
@@ -26,9 +26,8 @@ export default function WithdrawalHistory(_: any) {
       setLoading(true)
       setError('')
       try {
-        const params: any = { page, limit: perPage }
+        const params: any = { page, limit: perPage, ref: searchRef }
         if (statusFilter) params.status = statusFilter
-        if (searchRef) params.ref = searchRef
         if (startDate) params.fromDate = startDate.toISOString()
         if (endDate) params.toDate = endDate.toISOString()
 

--- a/frontend/src/pages/admin/clients/[clientId]/withdraw.tsx
+++ b/frontend/src/pages/admin/clients/[clientId]/withdraw.tsx
@@ -55,9 +55,8 @@ const AdminClientWithdrawPage: NextPage & { disableLayout?: boolean } = () => {
     if (!clientId) return
     setLoading(true)
     setPageError('')
-    const params: any = { page, limit: perPage }
+    const params: any = { page, limit: perPage, ref: searchRef }
     if (statusFilter) params.status = statusFilter
-    if (searchRef) params.ref = searchRef
     if (startDate) params.fromDate = startDate.toISOString()
     if (endDate) params.toDate = endDate.toISOString()
 

--- a/src/controller/withdrawals.controller.ts
+++ b/src/controller/withdrawals.controller.ts
@@ -103,8 +103,16 @@ export async function listWithdrawals(req: ClientAuthRequest, res: Response) {
   const childIds = user.partnerClient?.children.map(c => c.id) ?? [];
 
   // 2) Baca query.clientId (optional) untuk override single-child
-  const { clientId: qClientId, status, date_from, date_to, page = '1', limit = '20' } = req.query;
-    const fromDate = parseDateSafely(date_from);
+  const {
+    clientId: qClientId,
+    status,
+    date_from,
+    date_to,
+    ref,
+    page = '1',
+    limit = '20',
+  } = req.query;
+  const fromDate = parseDateSafely(date_from);
   const toDate   = parseDateSafely(date_to);
   let clientIds: string[];
   if (typeof qClientId === 'string' && qClientId !== 'all') {
@@ -120,6 +128,7 @@ export async function listWithdrawals(req: ClientAuthRequest, res: Response) {
     partnerClientId: { in: clientIds }
   };
   if (status) where.status = status as string;
+  if (ref)    where.refId = { contains: ref as string, mode: 'insensitive' };
   if (fromDate || toDate) {
     where.createdAt = {};
     if (fromDate) where.createdAt.gte = fromDate;

--- a/src/route/withdrawals.routes.ts
+++ b/src/route/withdrawals.routes.ts
@@ -133,6 +133,12 @@ router.get(
  *     summary: List all withdrawals for this client
  *     security:
  *       - clientAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: ref
+ *         schema:
+ *           type: string
+ *         description: Filter by partial reference ID (case-insensitive)
  *     responses:
  *       200:
  *         description: List of withdrawals


### PR DESCRIPTION
## Summary
- allow filtering withdrawals by `ref` query parameter
- document new `ref` filter and wire it through client requests

## Testing
- `npm test`
- `npm run build` *(fails: Module '@prisma/client' has no exported member 'DisbursementStatus')*
- `npm --prefix frontend run lint` *(interactive prompt: Next.js lint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2c8facd4832883127458af356c74