### PR TITLE
fix: prevent login redirect on non-auth errors

### DIFF
--- a/frontend/src/pages/client/dashboard.tsx
+++ b/frontend/src/pages/client/dashboard.tsx
@@ -136,8 +136,12 @@ export default function ClientDashboardPage() {
       setTotalPaid(data.totalPaid || 0)
       setChildren(data.children)
       setTotalTrans(data.totalCount)
-    } catch {
-      router.push('/client/login')
+    } catch (err: any) {
+      if (err?.response?.status === 401) {
+        router.push('/client/login')
+      } else {
+        console.error('Failed to fetch summary', err)
+      }
     } finally {
       setLoadingSummary(false)
     }
@@ -153,8 +157,12 @@ export default function ClientDashboardPage() {
       )
       setTxs(data.transactions)
       setTotalPages(Math.max(1, Math.ceil(data.total / perPage)))
-    } catch {
-      router.push('/client/login')
+    } catch (err: any) {
+      if (err?.response?.status === 401) {
+        router.push('/client/login')
+      } else {
+        console.error('Failed to fetch transactions', err)
+      }
     } finally {
       setLoadingTx(false)
     }


### PR DESCRIPTION
## Summary
- avoid redirecting to client login when dashboard data fetch fails for reasons other than authentication

## Testing
- `npm test` *(fails: Could not find '/workspace/launcxbaru/test/**/*.test.ts')*

------
https://chatgpt.com/codex/tasks/task_e_68ab2d9c2ec88328b5099ddf9e61f3f3