### PR TITLE
feat: add dashboard volume endpoint

### DIFF
--- a/src/route/admin/merchant.routes.ts
+++ b/src/route/admin/merchant.routes.ts
@@ -41,6 +41,7 @@ router.use('/:id/pg', subMerchantRouter)
 
 // Admin Dashboard: transaksi, summary, profit, withdrawals, export
 router.get('/dashboard/transactions', ctrl.getDashboardTransactions)
+router.get('/dashboard/volume',       ctrl.getDashboardVolume)
 router.get('/dashboard/summary',      ctrl.getDashboardSummary)
 router.get('/dashboard/profit',       ctrl.getPlatformProfit)
 router.get('/dashboard/profit-submerchant', ctrl.getProfitPerSubMerchant)

--- a/test/dashboardVolume.routes.test.ts
+++ b/test/dashboardVolume.routes.test.ts
@@ -1,0 +1,65 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import express from 'express'
+import request from 'supertest'
+
+process.env.JWT_SECRET = 'test'
+
+import { prisma } from '../src/core/prisma'
+const { getDashboardVolume } = require('../src/controller/admin/merchant.controller')
+
+test('getDashboardVolume returns raw transactions', async () => {
+  const now = new Date()
+  ;(prisma as any).order = {
+    findMany: async () => [
+      {
+        id: '1',
+        createdAt: now,
+        playerId: 'p1',
+        qrPayload: 'ref1',
+        rrn: 'rrn1',
+        amount: 100,
+        feeLauncx: 1,
+        fee3rdParty: 2,
+        pendingAmount: 50,
+        settlementAmount: 40,
+        status: 'PAID',
+        settlementStatus: 'DONE',
+        channel: 'QR',
+        paymentReceivedTime: now,
+        settlementTime: now,
+        trxExpirationTime: now,
+      },
+    ],
+  }
+  const app = express()
+  app.get('/dashboard/volume', getDashboardVolume)
+
+  const res = await request(app)
+    .get('/dashboard/volume')
+    .query({ date_from: now.toISOString(), date_to: now.toISOString() })
+
+  assert.equal(res.status, 200)
+  assert.deepEqual(res.body, {
+    transactions: [
+      {
+        id: '1',
+        date: now.toISOString(),
+        reference: 'ref1',
+        rrn: 'rrn1',
+        playerId: 'p1',
+        amount: 100,
+        feeLauncx: 1,
+        feePg: 2,
+        netSettle: 50,
+        status: 'PAID',
+        settlementStatus: 'DONE',
+        channel: 'QR',
+        paymentReceivedTime: now.toISOString(),
+        settlementTime: now.toISOString(),
+        trxExpirationTime: now.toISOString(),
+      },
+    ],
+  })
+})
+


### PR DESCRIPTION
## Summary
- add `getDashboardVolume` handler to return all transactions in a period without pagination
- expose `/dashboard/volume` route for admin merchants dashboard
- cover new volume endpoint with integration test

## Testing
- `node --test -r ts-node/register test/dashboardVolume.routes.test.ts`
- `node --test -r ts-node/register test/*.test.ts` *(fails: test failures 5/33)*

------
https://chatgpt.com/codex/tasks/task_e_68ab306d7dc88328aa596278760b88f0