### PR TITLE
Use paymentReceivedTime for dashboard volume date handling

### DIFF
--- a/src/controller/admin/merchant.controller.ts
+++ b/src/controller/admin/merchant.controller.ts
@@ -523,9 +523,9 @@ export async function getDashboardVolume(req: Request, res: Response) {
     const dateTo = date_to ? new Date(String(date_to)) : undefined;
     const searchStr = typeof search === 'string' ? search.trim() : '';
 
-    const createdAtFilter: any = {};
-    if (dateFrom && !isNaN(dateFrom.getTime())) createdAtFilter.gte = dateFrom;
-    if (dateTo && !isNaN(dateTo.getTime())) createdAtFilter.lte = dateTo;
+    const paymentTimeFilter: any = {};
+    if (dateFrom && !isNaN(dateFrom.getTime())) paymentTimeFilter.gte = dateFrom;
+    if (dateTo && !isNaN(dateTo.getTime())) paymentTimeFilter.lte = dateTo;
 
     const allowedStatuses = [
       'SUCCESS',
@@ -549,7 +549,7 @@ export async function getDashboardVolume(req: Request, res: Response) {
     }
 
     const whereOrders: any = {
-      ...(dateFrom || dateTo ? { createdAt: createdAtFilter } : {}),
+      ...(dateFrom || dateTo ? { paymentReceivedTime: paymentTimeFilter } : {}),
     };
     if (statusList) {
       whereOrders.status = { in: statusList };
@@ -569,7 +569,7 @@ export async function getDashboardVolume(req: Request, res: Response) {
 
     const orders = await prisma.order.findMany({
       where: whereOrders,
-      orderBy: { createdAt: 'asc' },
+      orderBy: { paymentReceivedTime: 'asc' },
       select: {
         id: true,
         createdAt: true,
@@ -597,7 +597,9 @@ export async function getDashboardVolume(req: Request, res: Response) {
 
       return {
         id: o.id,
-        date: o.createdAt.toISOString(),
+        date: o.paymentReceivedTime
+          ? o.paymentReceivedTime.toISOString()
+          : o.createdAt.toISOString(),
         reference: o.qrPayload ?? '',
         rrn: o.rrn ?? '',
         playerId: o.playerId,

--- a/test/dashboardVolume.routes.test.ts
+++ b/test/dashboardVolume.routes.test.ts
@@ -9,12 +9,13 @@ import { prisma } from '../src/core/prisma'
 const { getDashboardVolume } = require('../src/controller/admin/merchant.controller')
 
 test('getDashboardVolume returns raw transactions', async () => {
-  const now = new Date()
+  const paidAt = new Date()
+  const createdAt = new Date(paidAt.getTime() - 60_000)
   ;(prisma as any).order = {
     findMany: async () => [
       {
         id: '1',
-        createdAt: now,
+        createdAt,
         playerId: 'p1',
         qrPayload: 'ref1',
         rrn: 'rrn1',
@@ -26,9 +27,9 @@ test('getDashboardVolume returns raw transactions', async () => {
         status: 'PAID',
         settlementStatus: 'DONE',
         channel: 'QR',
-        paymentReceivedTime: now,
-        settlementTime: now,
-        trxExpirationTime: now,
+        paymentReceivedTime: paidAt,
+        settlementTime: paidAt,
+        trxExpirationTime: paidAt,
       },
     ],
   }
@@ -37,14 +38,14 @@ test('getDashboardVolume returns raw transactions', async () => {
 
   const res = await request(app)
     .get('/dashboard/volume')
-    .query({ date_from: now.toISOString(), date_to: now.toISOString() })
+    .query({ date_from: paidAt.toISOString(), date_to: paidAt.toISOString() })
 
   assert.equal(res.status, 200)
   assert.deepEqual(res.body, {
     transactions: [
       {
         id: '1',
-        date: now.toISOString(),
+        date: paidAt.toISOString(),
         reference: 'ref1',
         rrn: 'rrn1',
         playerId: 'p1',
@@ -55,9 +56,9 @@ test('getDashboardVolume returns raw transactions', async () => {
         status: 'PAID',
         settlementStatus: 'DONE',
         channel: 'QR',
-        paymentReceivedTime: now.toISOString(),
-        settlementTime: now.toISOString(),
-        trxExpirationTime: now.toISOString(),
+        paymentReceivedTime: paidAt.toISOString(),
+        settlementTime: paidAt.toISOString(),
+        trxExpirationTime: paidAt.toISOString(),
       },
     ],
   })


### PR DESCRIPTION
## Summary
- filter dashboard volume by `paymentReceivedTime` when provided
- send `paymentReceivedTime` as the `date` field for dashboard transactions
- expand unit test to verify mapping uses payment timestamp

## Testing
- `node --test -r ts-node/register test/dashboardVolume.routes.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68ab35aed2b083289c3b00d833a66a6b