### PR TITLE
Add granularity-based dashboard volume aggregation

### DIFF
--- a/test/dashboardVolume.routes.test.ts
+++ b/test/dashboardVolume.routes.test.ts
@@ -8,57 +8,25 @@ process.env.JWT_SECRET = 'test'
 import { prisma } from '../src/core/prisma'
 const { getDashboardVolume } = require('../src/controller/admin/merchant.controller')
 
-test('getDashboardVolume returns raw transactions', async () => {
+test('getDashboardVolume returns buckets', async () => {
   const paidAt = new Date()
-  const createdAt = new Date(paidAt.getTime() - 60_000)
-  ;(prisma as any).order = {
-    findMany: async () => [
-      {
-        id: '1',
-        createdAt,
-        playerId: 'p1',
-        qrPayload: 'ref1',
-        rrn: 'rrn1',
-        amount: 100,
-        feeLauncx: 1,
-        fee3rdParty: 2,
-        pendingAmount: 50,
-        settlementAmount: 40,
-        status: 'PAID',
-        settlementStatus: 'DONE',
-        channel: 'QR',
-        paymentReceivedTime: paidAt,
-        settlementTime: paidAt,
-        trxExpirationTime: paidAt,
-      },
-    ],
-  }
+  ;(prisma as any).$queryRaw = async () => [
+    { bucket: paidAt, totalAmount: 100, count: 2 },
+  ]
   const app = express()
   app.get('/dashboard/volume', getDashboardVolume)
 
   const res = await request(app)
     .get('/dashboard/volume')
-    .query({ date_from: paidAt.toISOString(), date_to: paidAt.toISOString() })
+    .query({ granularity: 'hour' })
 
   assert.equal(res.status, 200)
   assert.deepEqual(res.body, {
-    transactions: [
+    buckets: [
       {
-        id: '1',
-        date: paidAt.toISOString(),
-        reference: 'ref1',
-        rrn: 'rrn1',
-        playerId: 'p1',
-        amount: 100,
-        feeLauncx: 1,
-        feePg: 2,
-        netSettle: 50,
-        status: 'PAID',
-        settlementStatus: 'DONE',
-        channel: 'QR',
-        paymentReceivedTime: paidAt.toISOString(),
-        settlementTime: paidAt.toISOString(),
-        trxExpirationTime: paidAt.toISOString(),
+        bucket: paidAt.toISOString(),
+        totalAmount: 100,
+        count: 2,
       },
     ],
   })


### PR DESCRIPTION
## Summary
- support hour/day granularity for dashboard volume
- aggregate orders by truncated paymentReceivedTime and return buckets
- send granularity from dashboard page and render server-provided buckets

## Testing
- `node --test -r ts-node/register test/dashboardVolume.routes.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68ab3a05eba08328abf20876f993e405