### PR TITLE
Use COALESCE in dashboard volume query

### DIFF
--- a/test/dashboardVolume.routes.test.ts
+++ b/test/dashboardVolume.routes.test.ts
@@ -32,3 +32,17 @@ test('getDashboardVolume returns buckets', async () => {
   })
 })
 
+test('getDashboardVolume filters null buckets', async () => {
+  ;(prisma as any).$queryRaw = async () => [
+    { bucket: null, totalAmount: 50, count: 1 },
+  ]
+  const app = express()
+  app.get('/dashboard/volume', getDashboardVolume)
+
+  const res = await request(app)
+    .get('/dashboard/volume')
+
+  assert.equal(res.status, 200)
+  assert.deepEqual(res.body, { buckets: [] })
+})
+


### PR DESCRIPTION
## Summary
- Account for missing paymentReceivedTime by falling back to createdAt in dashboard volume query
- Filter and guard null buckets in dashboard volume response
- Add tests for null bucket handling

## Testing
- `npm test` *(fails: Could not find '/workspace/launcxbaru/test/**/*.test.ts')*
- `node --test -r ts-node/register test/dashboardVolume.routes.test.ts` *(fails: @prisma/client did not initialize yet)*

------
https://chatgpt.com/codex/tasks/task_e_68ab3def40648328acc2d6f10e486599