### PR TITLE
feat: add all status filter option to dashboard

### DIFF
--- a/frontend/src/components/dashboard/TransactionsTable.tsx
+++ b/frontend/src/components/dashboard/TransactionsTable.tsx
@@ -154,12 +154,13 @@ export default function TransactionsTable({
               aria-label="Filter status transaksi"
               className="w-full h-10 rounded-xl border border-neutral-800 bg-neutral-900 px-3 text-sm text-neutral-100 focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/30 outline-none"
             >
+              <option value="all">ALL</option>
               <option value="SUCCESS">SUCCESS</option>
               <option value="PAID">PAID</option>
               <option value="PENDING">PENDING</option>
               <option value="EXPIRED">EXPIRED</option>
-            </select>
-          </div>
+              </select>
+            </div>
 
           {/* Date range */}
           <div className="relative">

--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -183,7 +183,7 @@ export default function DashboardPage() {
   const [from, setFrom] = useState(() => fmtISODateJak(new Date()))
   const [to, setTo] = useState(() => fmtISODateJak(new Date()))
   const [search, setSearch] = useState('')
-  const [statusFilter, setStatusFilter] = useState<'SUCCESS' | 'PAID' | string>('PAID')
+  const [statusFilter, setStatusFilter] = useState('all')
   const [withdrawStatusFilter, setWithdrawStatusFilter] = useState('')
 
   const [totalPages, setTotalPages] = useState(1)


### PR DESCRIPTION
## Summary
- default dashboard status filter to `all`
- omit `status` query param when filter is set to `all`
- add `ALL` option to transactions status dropdown

## Testing
- `npm test` *(no tests found)*
- `(cd frontend && npm test)` *(fails: Missing script "test")*
- `(cd frontend && npm run lint)` *(warnings: `next lint` deprecated)*

------
https://chatgpt.com/codex/tasks/task_e_68ab3e67c4e883289afcf1793e1c973b