### PR TITLE
feat: centralize 24‑hour range calculation

### DIFF
--- a/src/controller/admin/merchant.controller.ts
+++ b/src/controller/admin/merchant.controller.ts
@@ -10,7 +10,7 @@ import ExcelJS from 'exceljs'
 import {OyClient,OyConfig}          from '../../service/oyClient'    // sesuaikan path
 import { GidiClient, GidiError } from '../../service/gidiClient'
 import { config } from '../../config';
-import { isJakartaWeekend, formatDateJakarta, parseDateSafely } from '../../util/time'
+import { isJakartaWeekend, formatDateJakarta, parseDateSafely, wibLast24HoursRange } from '../../util/time'
 import { parseRawCredential, normalizeCredentials } from '../../util/credentials';
 import { getCache, setCache } from '../../util/cache'
 import pLimit from 'p-limit'
@@ -514,9 +514,7 @@ export async function getDashboardVolume(req: Request, res: Response) {
   try {
     const { partnerClientId, status, search } = req.query as any;
 
-    const now = new Date();
-    const dateFrom = new Date(now.getTime() - 24 * 60 * 60 * 1000);
-    const dateTo = now;
+    const { start: dateFrom, end: dateTo } = wibLast24HoursRange();
     const searchStr = typeof search === 'string' ? search.trim() : '';
 
     const allowedStatuses = [

--- a/src/util/time.ts
+++ b/src/util/time.ts
@@ -15,6 +15,12 @@ export function wibTimestampString(): string {
   return moment().tz('Asia/Jakarta').format('YYYY-MM-DDTHH:mm:ss+07:00');
 }
 
+export function wibLast24HoursRange(): { start: Date; end: Date } {
+  const end = wibTimestamp();
+  const start = new Date(end.getTime() - 24 * 60 * 60 * 1000);
+  return { start, end };
+}
+
 
 let weekendOverrideDates = new Set<string>()
 


### PR DESCRIPTION
## Summary
- add utility to compute last 24h range in WIB timezone
- use the time range utility in dashboard volume query

## Testing
- `npm test` *(fails: JWT_SECRET environment variable is required and Prisma client not generated)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5ce189fc8328a5e2ba8faa51f9f8