### PR TITLE
feat(ifp): add payment channel fields for QR payments

### DIFF
--- a/scripts/ifp-script.ts
+++ b/scripts/ifp-script.ts
@@ -23,7 +23,7 @@ if (!amount || !customer.name) {
 (async () => {
   try {
     const client = new IfpClient();
-    const res = await client.createQrPayment({ amount, customer });
+    const res = await client.createQrPayment({ amount, customer, payment_channel: 'qris' });
     console.log('qr_string:', res.qr_string);
     console.log('qr_url   :', res.qr_url);
   } catch (err: any) {

--- a/src/service/ifpClient.ts
+++ b/src/service/ifpClient.ts
@@ -18,6 +18,15 @@ export interface QrPaymentRequest {
   customer_details?: Record<string, any>;
   wallet_details?: Record<string, any>;
   callback_url?: string;
+  currency?: string;
+  payment_method?: string;
+  payment_channel: string;
+  payment_details?: {
+    amount?: number;
+    expired_time?: number;
+    transaction_description?: string;
+    [key: string]: any;
+  };
   [key: string]: any;
 }
 
@@ -69,11 +78,19 @@ export class IfpClient {
     let body: any;
     let extId = req.external_id || Date.now().toString();
 
+    const paymentDetails = {
+      amount: req.amount,
+      ...(req.payment_details || {}),
+    };
+
     if (req.external_id) {
       body = {
         external_id: req.external_id,
         order_id: req.order_id || req.external_id,
-        amount: req.amount,
+        currency: req.currency || 'IDR',
+        payment_method: req.payment_method || 'wallet',
+        payment_channel: req.payment_channel,
+        payment_details: paymentDetails,
         customer_details: req.customer_details || {},
         wallet_details: req.wallet_details || {},
         callback_url: req.callback_url,
@@ -81,7 +98,10 @@ export class IfpClient {
     } else {
       body = {
         partnerReferenceNo: req.customer?.id || extId,
-        amount: { value: Number(req.amount).toFixed(2), currency: 'IDR' },
+        currency: req.currency || 'IDR',
+        payment_method: req.payment_method || 'wallet',
+        payment_channel: req.payment_channel,
+        payment_details: paymentDetails,
         additionalInfo: {
           customerName: req.customer?.name,
           customerPhone: req.customer?.phone,

--- a/src/service/payment.ts
+++ b/src/service/payment.ts
@@ -299,6 +299,7 @@ if (mName === 'ifp') {
     external_id: refId,
     order_id: refId,
     amount,
+    payment_channel: 'qris',
     customer_details: { id: pid, name: pid },
     wallet_details: {},
     callback_url: config.api.callbackUrl,

--- a/src/service/provider.ts
+++ b/src/service/provider.ts
@@ -255,6 +255,7 @@ export async function getActiveProvidersForClient(
         const client = new IfpClient(cfg);
         const resp = await client.createQrPayment({
           amount,
+          payment_channel: 'qris',
           customer: { name: orderId },
         });
         return resp.qr_string;
@@ -265,6 +266,7 @@ export async function getActiveProvidersForClient(
         const client = new IfpClient(cfg);
         const resp = await client.createQrPayment({
           amount,
+          payment_channel: 'qris',
           customer: { name: orderId },
         });
         return resp.qr_url;


### PR DESCRIPTION
## Summary
- support currency, payment method, and payment channel in QR payment requests
- require callers to supply payment_channel and nest amount in payment_details

## Testing
- `npm test`
- `npm run build` *(fails: Module '@prisma/client' has no exported member)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6e1e80b4832890be277263b30f17