### PR TITLE
Fix QR payment response types for Prisma JSON storage

### DIFF
--- a/src/service/ifpClient.ts
+++ b/src/service/ifpClient.ts
@@ -33,6 +33,7 @@ export interface QrPaymentRequest {
 export interface QrPaymentResponse {
   qr_string: string;
   qr_url: string;
+  [key: string]: any;
 }
 
 // Konfigurasi yang disimpan di database untuk IFP

--- a/src/service/payment.ts
+++ b/src/service/payment.ts
@@ -8,6 +8,7 @@ import { postWithRetry } from '../utils/postWithRetry';
 
 import { brevoAxiosInstance } from '../core/brevo.axios';
 import { prisma } from '../core/prisma';
+import { Prisma } from '@prisma/client';
 import logger from '../logger';
 import { generateRandomId, getRandomNumber } from '../util/random';
 import { getCurrentDate } from '../util/util';
@@ -242,7 +243,7 @@ const qrResp = await oyClient.createQRISTransaction({
   await prisma.transaction_response.create({
     data: {
       referenceId: refId,
-      responseBody: JSON.stringify(qrResp),
+      responseBody: qrResp as unknown as Prisma.InputJsonValue,
       playerId: pid,
     },
   })
@@ -339,7 +340,7 @@ if (mName === 'ifp') {
   await prisma.transaction_response.create({
     data: {
       referenceId: refId,
-      responseBody: qrResp,
+      responseBody: qrResp as unknown as Prisma.InputJsonValue,
       playerId: pid,
     },
   });


### PR DESCRIPTION
## Summary
- add index signature to `QrPaymentResponse` for Prisma JSON compatibility
- cast QRIS responses to `Prisma.InputJsonValue` when saving transaction responses

## Testing
- `npm run build`
- `npm test` *(fails: Could not find '/workspace/launcxbaru/test/**/*.test.ts')*

------
https://chatgpt.com/codex/tasks/task_e_68ab736e6bf483288acada08aae5a64d