### PR TITLE
Align custom volume title with Jakarta timezone

### DIFF
--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -630,7 +630,7 @@ export default function DashboardPage() {
       return `Payment Volume (${day.toLocaleDateString('id-ID', { timeZone: TZ })} • per jam)`
     }
     if (range === 'custom' && startDate && endDate) {
-      return `Payment Volume (${startDate.toLocaleDateString('id-ID')} – ${endDate.toLocaleDateString('id-ID')})`
+      return `Payment Volume (${startDate.toLocaleDateString('id-ID', { timeZone: TZ })} – ${endDate.toLocaleDateString('id-ID', { timeZone: TZ })})`
     }
     const map: Record<typeof range, string> = {
       today: 'Payment Volume (Hari ini)',


### PR DESCRIPTION
## Summary
- ensure custom range volume titles use `toLocaleDateString` with Jakarta timezone
- keep `TZ` constant at `Asia/Jakarta` for consistency

## Testing
- `npm test` *(fails: Could not find '/workspace/launcxbaru/test/**/*.test.ts')*


------
https://chatgpt.com/codex/tasks/task_e_68ab7f28a44883289256714a9a3f4c64