### PR TITLE
Fix dashboard volume series status filter

### DIFF
--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -6,6 +6,7 @@ import { useRequireAuth } from '@/hooks/useAuth'
 import { Wallet, ListChecks, Clock, Layers } from 'lucide-react'
 import dynamic from 'next/dynamic'
 import { Tx, Withdrawal, SubBalance } from '@/types/dashboard'
+import { Granularity, buildVolumeSeriesParams } from '@/utils/dashboard'
 import DatePicker from 'react-datepicker'
 import 'react-datepicker/dist/react-datepicker.css'
 import {
@@ -124,7 +125,6 @@ function getPresetBounds(range: 'today' | 'yesterday' | 'week' | 'month') {
 }
 
 // === Granularity & bucketing ===
-type Granularity = 'hour' | 'day'
 function isSameJakDay(a: Date, b: Date) {
   const aj = new Date(a.toLocaleString('en-US', { timeZone: TZ }))
   const bj = new Date(b.toLocaleString('en-US', { timeZone: TZ }))
@@ -506,10 +506,7 @@ export default function DashboardPage() {
   const fetchVolumeSeries = async () => {
     setLoadingVolume(true)
     try {
-      const params = buildParams()
-      delete params.page
-      delete params.limit
-      params.granularity = granularity
+      const params = buildVolumeSeriesParams(buildParams(), granularity)
       const { data } = await api.get<{ buckets: { bucket: string; totalAmount: number; count: number }[] }>(
         '/admin/merchants/dashboard/volume',
         { params }
@@ -601,7 +598,7 @@ export default function DashboardPage() {
   useEffect(() => {
     fetchVolumeSeries()
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [range, from, to, selectedMerchant, search, statusFilter, granularity])
+  }, [range, from, to, selectedMerchant, search, granularity])
 
   if (loadingSummary) {
     return (

--- a/frontend/src/utils/dashboard.test.ts
+++ b/frontend/src/utils/dashboard.test.ts
@@ -1,0 +1,11 @@
+import { test } from 'node:test'
+import assert from 'node:assert'
+import { buildVolumeSeriesParams } from './dashboard'
+
+test('buildVolumeSeriesParams forces PAID and SETTLED status', () => {
+  const params = buildVolumeSeriesParams({ page: 3, limit: 5, status: 'FAILED' }, 'day')
+  assert.deepStrictEqual(params.status, ['PAID', 'SETTLED'])
+  assert.ok(!('page' in params))
+  assert.ok(!('limit' in params))
+  assert.equal(params.granularity, 'day')
+})

--- a/frontend/src/utils/dashboard.ts
+++ b/frontend/src/utils/dashboard.ts
@@ -1,0 +1,13 @@
+export type Granularity = 'hour' | 'day'
+
+export function buildVolumeSeriesParams(
+  params: Record<string, any>,
+  granularity: Granularity
+) {
+  const p = { ...params }
+  delete (p as any).page
+  delete (p as any).limit
+  p.granularity = granularity
+  p.status = ['PAID', 'SETTLED']
+  return p
+}


### PR DESCRIPTION
## Summary
- Ensure dashboard volume chart queries only PAID and SETTLED statuses
- Remove status filter from volume chart effect dependencies
- Add unit test for volume query params enforcing fixed statuses

## Testing
- `node --test frontend/tmp-test/dashboard.test.js`
- `npm run lint` *(fails: prompts for ESLint setup)*
- `npm test` *(fails: Could not find '/workspace/launcxbaru/test/**/*.test.ts')*

------
https://chatgpt.com/codex/tasks/task_e_68ab86a95ddc83288a13e3bdaab7abc1