### PR TITLE
Refactor dashboard volume aggregation

### DIFF
--- a/test/dashboardVolume.routes.test.ts
+++ b/test/dashboardVolume.routes.test.ts
@@ -33,6 +33,9 @@ test('getDashboardVolume returns points', async () => {
   })
   assert(receivedPipeline?.some(s => s.$project?.timestamp?.$dateTrunc))
   assert(receivedPipeline?.some(s => s.$group?.count))
+  assert(receivedPipeline?.[0]?.$addFields?.baseTime?.$toDate)
+  assert(receivedPipeline?.[1]?.$match?.baseTime)
+  assert(receivedPipeline?.[1]?.$match?.status?.$in)
 })
 
 test('getDashboardVolume handles empty result', async () => {


### PR DESCRIPTION
## Summary
- derive a `baseTime` field for orders and filter on it
- update dashboard volume pipeline and tests for the new `baseTime` stage

## Testing
- `npm test` *(fails: 29 passed, 5 failed)*
- `node --test -r ts-node/register test/dashboardVolume.routes.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ab9346c32c8328b2eead0b8f1d020b