### PR TITLE
feat: add client API log endpoint

### DIFF
--- a/src/controller/clientApiLog.controller.ts
+++ b/src/controller/clientApiLog.controller.ts
@@ -1,0 +1,75 @@
+import { Response } from 'express'
+import { prisma } from '../core/prisma'
+import { ClientAuthRequest } from '../middleware/clientAuth'
+
+export async function getClientApiLogs(req: ClientAuthRequest, res: Response) {
+  const { page = '1', limit = '50' } = req.query as Record<string, any>
+  const pageNum = Math.max(1, parseInt(String(page), 10))
+  const pageSize = Math.min(100, parseInt(String(limit), 10))
+
+  const skip = (pageNum - 1) * pageSize
+  const take = pageSize + skip
+
+  const allowed = [req.partnerClientId!, ...(req.childrenIds ?? [])]
+
+  const [jobs, deadLetters, totalJobs, totalDeadLetters] = await Promise.all([
+    prisma.callbackJob.findMany({
+      where: { partnerClientId: { in: allowed } },
+      orderBy: { createdAt: 'desc' },
+      take,
+      select: {
+        id: true,
+        attempts: true,
+        delivered: true,
+        createdAt: true,
+        updatedAt: true,
+        lastError: true,
+        responseBody: true,
+      },
+    }),
+    prisma.callbackJobDeadLetter.findMany({
+      where: { partnerClientId: { in: allowed } },
+      orderBy: { createdAt: 'desc' },
+      take,
+      select: {
+        id: true,
+        attempts: true,
+        createdAt: true,
+        statusCode: true,
+        errorMessage: true,
+        responseBody: true,
+      },
+    }),
+    prisma.callbackJob.count({ where: { partnerClientId: { in: allowed } } }),
+    prisma.callbackJobDeadLetter.count({ where: { partnerClientId: { in: allowed } } }),
+  ])
+
+  const merged = [
+    ...jobs.map(j => ({
+      id: j.id,
+      status: j.delivered ? 'DELIVERED' : 'PENDING',
+      attempts: j.attempts,
+      createdAt: j.createdAt,
+      updatedAt: j.updatedAt,
+      statusCode: (j.lastError as any)?.statusCode ?? null,
+      errorMessage: (j.lastError as any)?.message ?? null,
+      responseBody: j.responseBody ?? null,
+    })),
+    ...deadLetters.map(d => ({
+      id: d.id,
+      status: 'FAILED',
+      attempts: d.attempts,
+      createdAt: d.createdAt,
+      updatedAt: d.createdAt,
+      statusCode: d.statusCode ?? null,
+      errorMessage: d.errorMessage ?? null,
+      responseBody: d.responseBody ?? null,
+    })),
+  ]
+
+  merged.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
+  const rows = merged.slice(skip, skip + pageSize)
+  const total = totalJobs + totalDeadLetters
+
+  return res.json({ rows, total })
+}

--- a/src/route/client.ts
+++ b/src/route/client.ts
@@ -3,6 +3,7 @@ import express, { Router } from 'express'
 import { clientLogin, clientRegister } from '../controller/clientAuth.controller'
 import { requireClientAuth }        from '../middleware/clientAuth'
 import { getClientDashboard }       from '../controller/clientDashboard.controller'
+import { getClientApiLogs } from '../controller/clientApiLog.controller'
 import {
   validateAccount,
   requestWithdraw,
@@ -21,6 +22,9 @@ r.use(requireClientAuth)
 
 // Dashboard
 r.get('/dashboard', getClientDashboard)
+
+// Callback API logs
+r.get('/api-logs', getClientApiLogs)
 
 // Withdrawal endpoints
 r.post(

--- a/src/route/client/web.routes.ts
+++ b/src/route/client/web.routes.ts
@@ -8,10 +8,11 @@ import {
   getClientDashboard,
   exportClientTransactions,
   getClientCallbackUrl,
-  
+
   updateClientCallbackUrl,
   retryTransactionCallback
 } from '../../controller/clientDashboard.controller'
+import { getClientApiLogs } from '../../controller/clientApiLog.controller'
 import withdrawalRoutes from '../withdrawals.routes'
 import { setupTOTP, enableTOTP, getTOTPStatus } from '../../controller/totp.controller'
 
@@ -38,6 +39,9 @@ r.post('/change-password', express.json(), changeClientPassword)
 r.get('/dashboard', getClientDashboard)
 r.get('/dashboard/export', exportClientTransactions)
 r.post('/callbacks/:id/retry', retryTransactionCallback)
+
+// Callback API logs
+r.get('/api-logs', getClientApiLogs)
 
 // Withdrawal endpoints
 r.use('/withdrawals', withdrawalRoutes)


### PR DESCRIPTION
## Summary
- add controller to paginate callback jobs and dead letters for clients
- expose `GET /api-logs` on client routes

## Testing
- `npm test` *(fails: Could not find '/workspace/launcxbaru/test/**/*.test.ts')*

------
https://chatgpt.com/codex/tasks/task_e_68aebe5e488083289b2f6e456b5eef97