### PR TITLE
Handle DB deadlock codes in settlement retries

### DIFF
--- a/src/cron/settlement.ts
+++ b/src/cron/settlement.ts
@@ -34,8 +34,10 @@ async function retryTx(fn: () => Promise<any>, attempts = 5, baseDelayMs = 100) 
     } catch (err: any) {
       lastErr = err;
       const msg = (err.message ?? '').toLowerCase();
-      const retryable = ['write conflict', 'transaction already closed', 'transaction timeout'];
-      const reason = retryable.find(r => msg.includes(r));
+      const code = String(err.code || '').toUpperCase();
+      const retryableMsgs = ['write conflict', 'transaction already closed', 'transaction timeout', 'deadlock detected'];
+      const retryableCodes = ['40P01', '40001', '55P03'];
+      const reason = retryableMsgs.find(r => msg.includes(r)) || (retryableCodes.includes(code) ? code : undefined);
       if (i < attempts - 1 && reason) {
         const delay = baseDelayMs * 2 ** i;
         logger.warn(


### PR DESCRIPTION
## Summary
- allow settlement retryTx to handle PostgreSQL deadlock and serialization errors by code or message

## Testing
- `npm test` *(fails: Could not find '/workspace/launcxbaru/test/**/*.test.ts')*

------
https://chatgpt.com/codex/tasks/task_e_68aed1bdb8288328986754d4b7353eee