### PR TITLE
feat: add settlement adjustment page

### DIFF
--- a/frontend/src/components/layouts/AdminLayout.tsx
+++ b/frontend/src/components/layouts/AdminLayout.tsx
@@ -14,6 +14,7 @@ import {
   FileText,
   User,
   Banknote,
+  Wrench,
 } from 'lucide-react'
 import { motion } from 'framer-motion'
 
@@ -29,6 +30,7 @@ const navItems = [
   { label: '2FA Setup',         href: '/admin/2fa',        Icon: ShieldCheck },
   { label: 'Settings',       href: '/admin/settings',   Icon: Settings },
   { label: 'Settlement',        href: '/admin/settlement', Icon: Banknote },
+  { label: 'Settlement Adjust', href: '/admin/settlement-adjust', Icon: Wrench },
   { label: 'Logs',              href: '/admin/logs',       Icon: FileText },
 ]
 

--- a/frontend/src/pages/admin/settlement-adjust.tsx
+++ b/frontend/src/pages/admin/settlement-adjust.tsx
@@ -1,0 +1,218 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import api from '@/lib/api'
+import { useRequireAuth } from '@/hooks/useAuth'
+import TransactionsTable from '@/components/dashboard/TransactionsTable'
+import { Tx } from '@/types/dashboard'
+import { AlertCircle, CheckCircle } from 'lucide-react'
+
+export default function SettlementAdjustPage() {
+  useRequireAuth()
+
+  const [transactionIds, setTransactionIds] = useState('')
+  const [startDate, setStartDate] = useState<Date | null>(null)
+  const [endDate, setEndDate] = useState<Date | null>(null)
+
+  const [txs, setTxs] = useState<Tx[]>([])
+  const [loadingTx, setLoadingTx] = useState(false)
+  const [search, setSearch] = useState('')
+  const [statusFilter, setStatusFilter] = useState('all')
+  const [perPage, setPerPage] = useState(10)
+  const [page, setPage] = useState(1)
+  const [totalPages, setTotalPages] = useState(1)
+  const [previewed, setPreviewed] = useState(false)
+
+  const [newStatus, setNewStatus] = useState('SETTLED')
+  const [settlementTime, setSettlementTime] = useState('')
+  const [fee, setFee] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [message, setMessage] = useState('')
+  const [error, setError] = useState('')
+
+  const buildParams = () => {
+    const p: any = { page, limit: perPage }
+    if (startDate) p.date_from = startDate.toISOString()
+    if (endDate) p.date_to = endDate.toISOString()
+    if (statusFilter !== 'all') p.status = statusFilter
+    if (search.trim()) p.search = search.trim()
+    return p
+  }
+
+  const mapTx = (o: any): Tx => ({
+    id: o.id,
+    date: o.date || o.createdAt || '',
+    rrn: o.rrn || '-',
+    playerId: o.playerId || '',
+    amount: o.amount || 0,
+    feeLauncx: o.feeLauncx || 0,
+    feePg: o.feePg || o.fee3rdParty || 0,
+    netSettle: o.netSettle ?? o.settlementAmount ?? 0,
+    status: o.status || '',
+    settlementStatus: o.settlementStatus || '',
+    channel: o.channel || '',
+    paymentReceivedTime: o.paymentReceivedTime || '',
+    settlementTime: o.settlementTime || '',
+    trxExpirationTime: o.trxExpirationTime || '',
+  })
+
+  const handleDateChange = (dates: [Date | null, Date | null]) => {
+    setStartDate(dates[0])
+    setEndDate(dates[1])
+  }
+
+  async function fetchTransactions() {
+    setError('')
+    setLoadingTx(true)
+    try {
+      const ids = transactionIds.split(/[\s,]+/).filter(Boolean)
+      let collected: Tx[] = []
+      if (ids.length > 0) {
+        for (const id of ids) {
+          const { data } = await api.get('/admin/merchants/dashboard/transactions', {
+            params: { search: id, limit: 1, page: 1 },
+          })
+          const mapped = (data.transactions || []).map(mapTx)
+          const found = mapped.find((t: Tx) => t.id === id)
+          if (found) collected.push(found)
+        }
+        setTotalPages(1)
+      } else {
+        const params = buildParams()
+        const { data } = await api.get('/admin/merchants/dashboard/transactions', { params })
+        const mapped = (data.transactions || []).map(mapTx)
+        setTotalPages(Math.max(1, Math.ceil((data.total || mapped.length) / perPage)))
+        collected = mapped
+      }
+      setTxs(collected)
+      setPreviewed(true)
+    } catch (e: any) {
+      setError(e?.response?.data?.error || 'Failed to fetch transactions')
+    } finally {
+      setLoadingTx(false)
+    }
+  }
+
+  useEffect(() => {
+    if (previewed) fetchTransactions()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [page, perPage])
+
+  const submit = async () => {
+    setSubmitting(true)
+    setError('')
+    setMessage('')
+    try {
+      const ids = transactionIds.split(/[\s,]+/).filter(Boolean)
+      const payload: any = { settlementStatus: newStatus }
+      if (ids.length) payload.transactionIds = ids
+      if (startDate) payload.dateFrom = startDate.toISOString()
+      if (endDate) payload.dateTo = endDate.toISOString()
+      if (settlementTime) payload.settlementTime = new Date(settlementTime).toISOString()
+      if (fee) payload.feeLauncx = Number(fee)
+      const { data } = await api.post('/admin/settlement/adjust', payload)
+      setMessage(`Updated ${data.data.updated} transactions`)
+    } catch (e: any) {
+      setError(e?.response?.data?.error || 'Failed to adjust settlements')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="dark min-h-screen bg-neutral-950 text-neutral-100 p-4 sm:p-6">
+      <div className="mx-auto max-w-6xl space-y-4">
+        <header className="mb-4">
+          <h1 className="text-xl font-semibold">Settlement Adjustment</h1>
+          <p className="text-xs text-neutral-400">Update settlement status and fee for selected transactions</p>
+        </header>
+
+        {(message || error) && (
+          <div className="space-y-2">
+            {message && (
+              <div className="inline-flex items-center gap-2 rounded-lg border border-emerald-900/40 bg-emerald-950/40 px-3 py-2 text-sm text-emerald-300">
+                <CheckCircle size={16} /> {message}
+              </div>
+            )}
+            {error && (
+              <div className="inline-flex items-center gap-2 rounded-lg border border-rose-900/40 bg-rose-950/40 px-3 py-2 text-sm text-rose-300">
+                <AlertCircle size={16} /> {error}
+              </div>
+            )}
+          </div>
+        )}
+
+        <section className="rounded-2xl border border-neutral-800 bg-neutral-900/70 p-4 sm:p-5 shadow-sm space-y-3">
+          <textarea
+            placeholder="Transaction IDs (comma or newline separated)"
+            className="w-full h-24 rounded-xl border border-neutral-800 bg-neutral-900 p-3 text-sm placeholder:text-neutral-500 focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/30 outline-none"
+            value={transactionIds}
+            onChange={e => setTransactionIds(e.target.value)}
+          />
+          <button
+            onClick={() => {
+              setPage(1)
+              fetchTransactions()
+            }}
+            className="h-10 rounded-xl bg-indigo-600 px-4 text-sm font-medium text-white hover:bg-indigo-500"
+          >
+            Preview Transactions
+          </button>
+        </section>
+
+        <div className="rounded-2xl border border-neutral-800 bg-neutral-900/70 shadow-sm">
+          <TransactionsTable
+            search={search}
+            setSearch={setSearch}
+            statusFilter={statusFilter}
+            setStatusFilter={setStatusFilter}
+            loadingTx={loadingTx}
+            txs={txs}
+            perPage={perPage}
+            setPerPage={setPerPage}
+            page={page}
+            setPage={setPage}
+            totalPages={totalPages}
+            buildParams={buildParams}
+            onDateChange={handleDateChange}
+          />
+        </div>
+
+        <section className="rounded-2xl border border-neutral-800 bg-neutral-900/70 p-4 sm:p-5 shadow-sm space-y-3">
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+            <select
+              value={newStatus}
+              onChange={e => setNewStatus(e.target.value)}
+              className="h-10 rounded-xl border border-neutral-800 bg-neutral-900 px-3 text-sm focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/30 outline-none"
+            >
+              <option value="SETTLED">SETTLED</option>
+              <option value="WAITING">WAITING</option>
+              <option value="UNSUCCESSFUL">UNSUCCESSFUL</option>
+            </select>
+            <input
+              type="datetime-local"
+              value={settlementTime}
+              onChange={e => setSettlementTime(e.target.value)}
+              className="h-10 rounded-xl border border-neutral-800 bg-neutral-900 px-3 text-sm focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/30 outline-none"
+            />
+            <input
+              type="number"
+              placeholder="Launcx Fee"
+              value={fee}
+              onChange={e => setFee(e.target.value)}
+              className="h-10 rounded-xl border border-neutral-800 bg-neutral-900 px-3 text-sm focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/30 outline-none"
+            />
+          </div>
+          <button
+            onClick={submit}
+            disabled={submitting}
+            className="h-10 rounded-xl bg-indigo-600 px-4 text-sm font-medium text-white hover:bg-indigo-500 disabled:opacity-50"
+          >
+            {submitting ? 'Submitting…' : 'Submit Adjustment'}
+          </button>
+        </section>
+      </div>
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add admin settlement adjustment page to preview and edit settlements
- link settlement adjustment page in admin navigation

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68ba891449f08328b47af142af86d527