### PR TITLE
Validate settlement adjustment parameter combinations

### DIFF
--- a/src/controller/admin/settlementAdjustment.controller.ts
+++ b/src/controller/admin/settlementAdjustment.controller.ts
@@ -11,10 +11,16 @@ export async function adjustSettlements(req: AuthRequest, res: Response) {
     return res.status(400).json({ error: 'settlementStatus required' })
   }
 
+  const hasIds = Array.isArray(transactionIds) && transactionIds.length > 0
+  const hasDateRange = Boolean(dateFrom || dateTo)
+  if (hasIds && hasDateRange) {
+    return res.status(400).json({ error: 'provide either transactionIds or date range, not both' })
+  }
+
   const where: any = {}
-  if (Array.isArray(transactionIds) && transactionIds.length > 0) {
+  if (hasIds) {
     where.id = { in: transactionIds }
-  } else if (dateFrom || dateTo) {
+  } else if (hasDateRange) {
     const createdAt: any = {}
     if (dateFrom) createdAt.gte = new Date(dateFrom)
     if (dateTo) createdAt.lte = new Date(dateTo)

--- a/test/settlementAdjustment.routes.test.ts
+++ b/test/settlementAdjustment.routes.test.ts
@@ -1,0 +1,55 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import express from 'express'
+import request from 'supertest'
+
+process.env.JWT_SECRET = 'test'
+
+const prismaPath = require.resolve('../src/core/prisma')
+require.cache[prismaPath] = {
+  id: prismaPath,
+  filename: prismaPath,
+  loaded: true,
+  exports: {
+    prisma: {
+      order: { findMany: async () => [], update: async () => {} },
+      transaction_request: { findMany: async () => [], update: async () => {} },
+    },
+  },
+} as any
+
+import * as adminLog from '../src/util/adminLog'
+;(adminLog as any).logAdminAction = async () => {}
+
+const { adjustSettlements } = require('../src/controller/admin/settlementAdjustment.controller')
+
+const app = express()
+app.use(express.json())
+app.post('/settlement/adjust', (req, res) => {
+  ;(req as any).userId = 'admin1'
+  adjustSettlements(req as any, res)
+})
+
+test('rejects when transactionIds and date range both provided', async () => {
+  const res = await request(app)
+    .post('/settlement/adjust')
+    .send({
+      transactionIds: ['1'],
+      dateFrom: '2024-01-01',
+      dateTo: '2024-01-02',
+      settlementStatus: 'pending',
+    })
+  assert.equal(res.status, 400)
+  assert.equal(res.body.error, 'provide either transactionIds or date range, not both')
+})
+
+test('rejects when neither transactionIds nor date range provided', async () => {
+  const res = await request(app)
+    .post('/settlement/adjust')
+    .send({
+      settlementStatus: 'pending',
+    })
+  assert.equal(res.status, 400)
+  assert.equal(res.body.error, 'transactionIds or date range required')
+})
+


### PR DESCRIPTION
## Summary
- ensure settlement adjustments accept either transaction IDs or date range, not both
- add tests for invalid settlement adjustment inputs

## Testing
- `node --test -r ts-node/register test/settlementAdjustment.routes.test.ts`
- `node --test -r ts-node/register $(find test -name '*.test.ts')` *(fails: JWT_SECRET environment variable is required)*

------
https://chatgpt.com/codex/tasks/task_e_68baa415b6bc8328aa2d334a167452d1