### PR TITLE
Fix TransactionsTable type and configure Next.js workspace root

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,6 +1,9 @@
-/** @type {import('next').NextConfig} */
-const nextConfig = {
+import type { NextConfig } from 'next'
+import path from 'path'
+
+const nextConfig: NextConfig = {
   reactStrictMode: true,
+  outputFileTracingRoot: path.resolve(__dirname, '..'),
 }
 
-module.exports = nextConfig
+export default nextConfig

--- a/frontend/src/components/dashboard/TransactionsTable.tsx
+++ b/frontend/src/components/dashboard/TransactionsTable.tsx
@@ -45,6 +45,7 @@ export default function TransactionsTable({
   totalPages,
   buildParams,
   onDateChange,
+  onSelectIds,
 }: TransactionsTableProps) {
   const [dateRange, setDateRange] = useState<[Date | null, Date | null]>([null, null])
   const [selectedIds, setSelectedIds] = useState<string[]>([])


### PR DESCRIPTION
## Summary
- include `onSelectIds` prop in `TransactionsTable` to avoid undefined reference
- set `outputFileTracingRoot` in Next.js config to silence monorepo warning

## Testing
- `npm test` *(fails: Could not find '/workspace/launcxbaru/test/**/*.test.ts')*
- `npm --prefix frontend run build`


------
https://chatgpt.com/codex/tasks/task_e_68baa90585048328ae4e4bdb6dbfd7a3