### PR TITLE
Ensure settlement adjustments update order status

### DIFF
--- a/src/controller/admin/settlementAdjustment.controller.ts
+++ b/src/controller/admin/settlementAdjustment.controller.ts
@@ -65,11 +65,12 @@ export async function adjustSettlements(req: AuthRequest, res: Response) {
       where: { id: o.id },
       data: {
         settlementStatus,
+        status: settlementStatus,
         ...(settlementTime && { settlementTime: new Date(settlementTime) }),
         feeLauncx: newFee,
         settlementAmount,
-        pendingAmount: null,
-      }
+        ...(settlementStatus === 'SETTLED' && { pendingAmount: null }),
+      },
     })
     updates.push({ id: o.id, model: 'order', settlementAmount })
   }

--- a/test/settlementAdjustment.routes.test.ts
+++ b/test/settlementAdjustment.routes.test.ts
@@ -67,3 +67,22 @@ test('returns ids of updated settlements', async () => {
   assert.equal(res.body.data.updated, 1)
 })
 
+test('adjusting PAID order to SETTLED updates status', async () => {
+  const prisma = require.cache[prismaPath].exports.prisma
+  prisma.order.findMany = async () => [
+    { id: 'o2', amount: 200, fee3rdParty: 0, feeLauncx: 0 },
+  ]
+  prisma.transaction_request.findMany = async () => []
+  let updatedData: any
+  prisma.order.update = async ({ data }: any) => {
+    updatedData = data
+    return {}
+  }
+  const res = await request(app)
+    .post('/settlement/adjust')
+    .send({ transactionIds: ['o2'], settlementStatus: 'SETTLED' })
+  assert.equal(res.status, 200)
+  assert.equal(updatedData.status, 'SETTLED')
+  assert.equal(updatedData.pendingAmount, null)
+})
+


### PR DESCRIPTION
## Summary
- Set order status during settlement adjustments and clear pending amount when settled
- Add regression test for settling a previously paid order

## Testing
- `node --test -r ts-node/register test/settlementAdjustment.routes.test.ts`
- `node --test -r ts-node/register test/**/*.test.ts` *(fails: @prisma/client did not initialize yet)*

------
https://chatgpt.com/codex/tasks/task_e_68bab013ae9483289ed21225fe7adb3a