### PR TITLE
Separate order and transaction filters for settlement adjustment

### DIFF
--- a/src/controller/admin/settlementAdjustment.controller.ts
+++ b/src/controller/admin/settlementAdjustment.controller.ts
@@ -17,89 +17,97 @@ export async function adjustSettlements(req: AuthRequest, res: Response) {
     return res.status(400).json({ error: 'provide either transactionIds or date range, not both' })
   }
 
-  const where: any = { status: 'PAID' }
+  const orderWhere: any = { status: 'PAID' }
+  const trxWhere: any = { status: 'SUCCESS' }
   if (hasIds) {
-    where.id = { in: transactionIds }
+    orderWhere.id = { in: transactionIds }
+    trxWhere.id = { in: transactionIds }
   } else if (hasDateRange) {
     const createdAt: any = {}
     if (dateFrom) createdAt.gte = new Date(dateFrom)
     if (dateTo) createdAt.lte = new Date(dateTo)
-    where.createdAt = createdAt
+    orderWhere.createdAt = createdAt
+    trxWhere.createdAt = createdAt
   } else {
     return res.status(400).json({ error: 'transactionIds or date range required' })
   }
 
-  const orders = await prisma.order.findMany({
-    where,
-    select: {
-      id: true,
-      amount: true,
-      fee3rdParty: true,
-      feeLauncx: true,
-    }
-  })
-
-  const oldTrx = await prisma.transaction_request.findMany({
-    where,
-    select: {
-      id: true,
-      amount: true,
-      settlementAmount: true,
-    }
-  })
-
-  const feeInput = feeLauncx
-  const getFee = (id: string, existing?: number | null) => {
-    if (typeof feeInput === 'number') return feeInput
-    if (feeInput && typeof feeInput === 'object') return feeInput[id] ?? existing ?? 0
-    return existing ?? 0
-  }
-
-  const updates: { id: string; model: 'order' | 'trx'; settlementAmount: number }[] = []
-
-  for (const o of orders) {
-    const netAmount = o.amount - (o.fee3rdParty ?? 0)
-    const newFee = getFee(o.id, o.feeLauncx ?? undefined)
-    const { settlement: settlementAmount } = computeSettlement(netAmount, { flat: newFee })
-    await prisma.order.update({
-      where: { id: o.id },
-      data: {
-        settlementStatus,
-        ...(settlementTime && { settlementTime: new Date(settlementTime) }),
-        feeLauncx: newFee,
-        settlementAmount,
-        ...(settlementStatus === 'SETTLED' && { pendingAmount: null }),
-      },
-    })
-    updates.push({ id: o.id, model: 'order', settlementAmount })
-  }
-
-  for (const t of oldTrx) {
-    const netAmount = t.settlementAmount ?? t.amount
-    const newFee = getFee(t.id)
-    const { settlement: settlementAmount } = computeSettlement(netAmount, { flat: newFee })
-    await prisma.transaction_request.update({
-      where: { id: t.id },
-      data: {
-        ...(settlementTime && { settlementAt: new Date(settlementTime) }),
-        settlementAmount,
+  try {
+    const orders = await prisma.order.findMany({
+      where: orderWhere,
+      select: {
+        id: true,
+        amount: true,
+        fee3rdParty: true,
+        feeLauncx: true,
       }
     })
-    updates.push({ id: t.id, model: 'trx', settlementAmount })
-  }
 
-  if (req.userId) {
-    await logAdminAction(req.userId, 'adjustSettlements', null, {
-      transactionIds,
-      dateFrom,
-      dateTo,
-      settlementStatus,
-      settlementTime,
-      feeLauncx,
-      updated: updates.map(u => ({ id: u.id, model: u.model, settlementAmount: u.settlementAmount })),
+    const oldTrx = await prisma.transaction_request.findMany({
+      where: trxWhere,
+      select: {
+        id: true,
+        amount: true,
+        settlementAmount: true,
+      }
     })
-  }
 
-  res.json({ data: { updated: updates.length, ids: updates.map(u => u.id) } })
+    const feeInput = feeLauncx
+    const getFee = (id: string, existing?: number | null) => {
+      if (typeof feeInput === 'number') return feeInput
+      if (feeInput && typeof feeInput === 'object') return feeInput[id] ?? existing ?? 0
+      return existing ?? 0
+    }
+
+    const updates: { id: string; model: 'order' | 'trx'; settlementAmount: number }[] = []
+
+    for (const o of orders) {
+      const netAmount = o.amount - (o.fee3rdParty ?? 0)
+      const newFee = getFee(o.id, o.feeLauncx ?? undefined)
+      const { settlement: settlementAmount } = computeSettlement(netAmount, { flat: newFee })
+      await prisma.order.update({
+        where: { id: o.id },
+        data: {
+          settlementStatus,
+          ...(settlementTime && { settlementTime: new Date(settlementTime) }),
+          feeLauncx: newFee,
+          settlementAmount,
+          ...(settlementStatus === 'SETTLED' && { pendingAmount: null }),
+        },
+      })
+      updates.push({ id: o.id, model: 'order', settlementAmount })
+    }
+
+    for (const t of oldTrx) {
+      const netAmount = t.settlementAmount ?? t.amount
+      const newFee = getFee(t.id)
+      const { settlement: settlementAmount } = computeSettlement(netAmount, { flat: newFee })
+      await prisma.transaction_request.update({
+        where: { id: t.id },
+        data: {
+          ...(settlementTime && { settlementAt: new Date(settlementTime) }),
+          settlementAmount,
+        }
+      })
+      updates.push({ id: t.id, model: 'trx', settlementAmount })
+    }
+
+    if (req.userId) {
+      await logAdminAction(req.userId, 'adjustSettlements', null, {
+        transactionIds,
+        dateFrom,
+        dateTo,
+        settlementStatus,
+        settlementTime,
+        feeLauncx,
+        updated: updates.map(u => ({ id: u.id, model: u.model, settlementAmount: u.settlementAmount })),
+      })
+    }
+
+    res.json({ data: { updated: updates.length, ids: updates.map(u => u.id) } })
+  } catch (err) {
+    console.error(err)
+    res.status(500).json({ error: 'internal error' })
+  }
 }
 


### PR DESCRIPTION
## Summary
- Use dedicated filters for orders and transaction requests in settlement adjustment
- Apply transaction-request updates and handle invalid enum errors gracefully
- Extend route tests to cover transaction_request updates and error handling

## Testing
- `node --test -r ts-node/register test/*.test.ts` *(fails: JWT_SECRET environment variable is required)*
- `node --test -r ts-node/register test/settlementAdjustment.routes.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68bac5e3d7848328a677d8b6be5bb391