### PR TITLE
feat: handle async errors

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,3 +1,4 @@
+import 'express-async-errors';
 import express, { Request, Response, NextFunction } from 'express';
 import helmet from 'helmet';
 import rateLimit from 'express-rate-limit';

--- a/test/async-error.test.ts
+++ b/test/async-error.test.ts
@@ -1,0 +1,18 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import express from 'express'
+import request from 'supertest'
+import 'express-async-errors'
+import { errorHandler } from '../src/middleware/errorHandler'
+
+test('async route errors return 500', async () => {
+  const app = express()
+  app.get('/fail', async () => {
+    throw new Error('boom')
+  })
+  app.use(errorHandler)
+
+  const res = await request(app).get('/fail')
+  assert.equal(res.status, 500)
+  assert.deepEqual(res.body, { error: 'Internal Server Error' })
+})


### PR DESCRIPTION
## Summary
- import `express-async-errors` in app to capture async handler failures
- add regression test ensuring async route errors return 500

## Testing
- `JWT_SECRET=test node --test -r ts-node/register test/async-error.test.ts`
- `FILES=$(find test -name '*.test.ts' -print); JWT_SECRET=test timeout 30s node --test -r ts-node/register $FILES` *(fails: pass 15 fail 11)*

------
https://chatgpt.com/codex/tasks/task_e_68bac6d50ec08328ba4cabe6204eec63