### PR TITLE
feat: add transaction cursor pagination and index

### DIFF
--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -89,6 +89,7 @@ model transaction_request {
   @@index([merchantId])
   @@index([createdAt])
   @@index([status])
+  @@index([merchantId, status, createdAt])
 }
 
 /// Simpan response mentah dari gateway


### PR DESCRIPTION
## Summary
- add composite index for transaction_request on merchantId/status/createdAt
- switch listTransactions to cursor-based pagination with optional count aggregation

## Testing
- `npm run generate`
- `timeout 5 npx prisma db push --schema=src/prisma/schema.prisma` *(fails: connection timed out)*
- `npm run build`
- `npm test` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68bbb57875a0832880e465cecad3ae19