### PR TITLE
feat: allow updating withdrawal requests

### DIFF
--- a/frontend/src/types/dashboard.ts
+++ b/frontend/src/types/dashboard.ts
@@ -37,6 +37,28 @@ export interface Withdrawal {
   wallet: string
 }
 
+export type WithdrawalUpdate = Partial<
+  Pick<
+    Withdrawal,
+    |
+      'accountName'
+    | 'accountNameAlias'
+    | 'accountNumber'
+    | 'bankCode'
+    | 'bankName'
+    | 'branchName'
+    | 'amount'
+    | 'withdrawFeePercent'
+    | 'withdrawFeeFlat'
+    | 'pgFee'
+    | 'netAmount'
+    | 'paymentGatewayId'
+    | 'isTransferProcess'
+    | 'status'
+    | 'completedAt'
+  >
+>
+
 export type SubBalance = {
   id: string
   name: string

--- a/src/route/admin/merchant.routes.ts
+++ b/src/route/admin/merchant.routes.ts
@@ -47,6 +47,11 @@ router.get('/dashboard/profit',       ctrl.getPlatformProfit)
 router.get('/dashboard/profit-submerchant', ctrl.getProfitPerSubMerchant)
 
 router.get('/dashboard/withdrawals',  ctrl.getDashboardWithdrawals)
+router.patch(
+  '/dashboard/withdrawals/:refId',
+  requireSuperAdminAuth,
+  ctrl.updateWithdrawal
+)
 router.post('/dashboard/withdraw', adminIpWhitelist, requireSuperAdminAuth, ctrl.adminWithdraw)
 router.post(
   '/dashboard/validate-account',


### PR DESCRIPTION
## Summary
- add controller to update withdraw requests via Prisma
- expose secured PATCH route for editing withdrawals
- add dashboard editing UI and type helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c4e962e340832894fcbf775512fc15