### PR TITLE
feat: add client balance editing

### DIFF
--- a/src/controller/admin/client.controller.ts
+++ b/src/controller/admin/client.controller.ts
@@ -20,6 +20,7 @@ export const getAllClients = async (_: Request, res: Response) => {
       isActive:       true,
       feePercent:     true,
       feeFlat:        true,
+      balance:        true,
       weekendFeePercent: true,
       weekendFeeFlat:    true,
       withdrawFeePercent: true,
@@ -190,7 +191,8 @@ export const updateClient = async (req: AuthRequest, res: Response) => {
     defaultProvider,
     forceSchedule,
     parentClientId = null,
-    childrenIds = []
+    childrenIds = [],
+    balance,
   } = req.body as {
     name?: string
     isActive?: boolean
@@ -204,6 +206,7 @@ export const updateClient = async (req: AuthRequest, res: Response) => {
     forceSchedule?: string
     parentClientId?: string | null
     childrenIds?: string[]
+    balance?: number
   }
 
   // validasi sederhana
@@ -264,6 +267,11 @@ export const updateClient = async (req: AuthRequest, res: Response) => {
       return res.status(400).json({ error: `defaultProvider must be one of ${allowed.join(', ')}` })
     }
     data.defaultProvider = dp
+  }
+  if (balance != null) {
+    const b = Number(balance)
+    if (isNaN(b)) return res.status(400).json({ error: 'balance must be a number' })
+    data.balance = b
   }
   data.parentClientId = parentClientId || null
 


### PR DESCRIPTION
## Summary
- display client balances and support inline editing in admin client table
- allow backend to expose and update client balance

## Testing
- `npm test` *(fails: Could not find '/workspace/launcxbaru/test/**/*.test.ts')*


------
https://chatgpt.com/codex/tasks/task_e_68c4ecd6044083289eed161bd8a9bc35