### PR TITLE
feat: allow admins to adjust client balance

### DIFF
--- a/src/route/admin/client.routes.ts
+++ b/src/route/admin/client.routes.ts
@@ -2,6 +2,7 @@
 import { Router } from 'express'
 import { authMiddleware } from '../../middleware/auth'
 import * as ctrl from '../../controller/admin/client.controller'
+import validator from '../../validation/validation'
 
 const router = Router()
 
@@ -24,6 +25,12 @@ router.get('/:clientId/dashboard', ctrl.getClientDashboardAdmin)
 router.get('/:clientId/withdrawals', ctrl.getClientWithdrawalsAdmin)
 router.get('/:clientId/subwallets',  ctrl.getClientSubWallets)
 router.post('/:clientId/reconcile-balance', ctrl.reconcileClientBalance)
+router.patch(
+  '/:clientId/balance',
+  validator.adjustClientBalanceValidation,
+  validator.handleValidationErrors,
+  ctrl.adjustClientBalance
+)
 
 // 3) [Dihapus] Koneksi PG per client
 // Feature deprecated: fee kini ditetapkan global di PartnerClient

--- a/src/validation/validation.ts
+++ b/src/validation/validation.ts
@@ -234,6 +234,26 @@ const confirmCardSessionValidation = [
     }),
 ];
 
+const adjustClientBalanceValidation = [
+  body('newBalance')
+    .optional()
+    .isNumeric()
+    .withMessage('newBalance must be a number'),
+  body('delta')
+    .optional()
+    .isNumeric()
+    .withMessage('delta must be a number'),
+  body().custom((value) => {
+    if (value.newBalance == null && value.delta == null) {
+      throw new Error('newBalance or delta required');
+    }
+    if (value.newBalance != null && value.delta != null) {
+      throw new Error('Provide either newBalance or delta, not both');
+    }
+    return true;
+  }),
+];
+
 const validation = {
   handleValidationErrors,
   initiatePaymentValidation,
@@ -243,6 +263,7 @@ const validation = {
   checkAccountValidation,
   createCardSessionValidation,
   confirmCardSessionValidation,
+  adjustClientBalanceValidation,
 };
 
 export default validation;


### PR DESCRIPTION
## Summary
- allow admins to adjust a client's balance via new controller handler
- expose PATCH /:clientId/balance route with input validation
- add express-validator schema for adjusting client balance

## Testing
- `npm test` *(fails: Could not find '/workspace/launcxbaru/test/**/*.test.ts')*

------
https://chatgpt.com/codex/tasks/task_e_68c4edfa0af88328b4f5420ee3713d56