### PR TITLE
fix: update client balances route in admin layout

### DIFF
--- a/frontend/src/components/layouts/AdminLayout.tsx
+++ b/frontend/src/components/layouts/AdminLayout.tsx
@@ -26,7 +26,7 @@ interface AdminLayoutProps {
 const navItems = [
   { label: 'Dashboard',         href: '/dashboard',        Icon: Home },
   { label: 'API Clients',       href: '/admin/clients',    Icon: Box },
-  { label: 'Client Balances',   href: '/admin/clients',    Icon: Wallet },
+  { label: 'Client Balances',   href: '/admin/client-balances',    Icon: Wallet },
   { label: 'Merchant Settings', href: '/admin/merchants',  Icon: BoomBox },
   { label: 'Admins',            href: '/admin/users',      Icon: User },
   { label: '2FA Setup',         href: '/admin/2fa',        Icon: ShieldCheck },


### PR DESCRIPTION
## Summary
- update Client Balances nav item to route to `/admin/client-balances`

## Testing
- `npm test` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_68c4f499d6348328b905c3c066b3a63b