### PR TITLE
Use new balance field when saving client balance

### DIFF
--- a/frontend/src/pages/admin/client-balances/index.tsx
+++ b/frontend/src/pages/admin/client-balances/index.tsx
@@ -67,7 +67,7 @@ export default function ClientBalancesPage() {
     setErr('')
     setSaving(true)
     try {
-      await api.patch(`/admin/clients/${id}/balance`, { balance: balanceEdit })
+      await api.patch(`/admin/clients/${id}/balance`, { newBalance: balanceEdit })
       await loadClients()
       setEditingId(null)
     } catch {


### PR DESCRIPTION
## Summary
- send `newBalance` field when updating client balance from admin panel

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint config)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c7b1f875008328a44502e481297e5b