### PR TITLE
feat: add S2S withdrawal endpoint

### DIFF
--- a/docs/api/withdrawal.s2s.yaml
+++ b/docs/api/withdrawal.s2s.yaml
@@ -1,0 +1,102 @@
+openapi: 3.0.0
+info:
+  title: Withdrawal S2S API
+  version: 1.0.0
+paths:
+  /withdrawals:
+    post:
+      summary: Create a new withdrawal
+      security:
+        - apiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/WithdrawalRequest"
+      responses:
+        "200":
+          description: Withdrawal created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WithdrawalResponse"
+    get:
+      summary: List all withdrawals for this client
+      security:
+        - apiKeyAuth: []
+      parameters:
+        - in: query
+          name: ref
+          schema:
+            type: string
+          description: Filter by partial reference ID (case-insensitive)
+      responses:
+        "200":
+          description: List of withdrawals
+  /withdrawals/validate-account:
+    post:
+      summary: Validate destination account
+      security:
+        - apiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ValidateAccountRequest"
+      responses:
+        "200":
+          description: Account validated
+components:
+  securitySchemes:
+    apiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-Key
+  schemas:
+    ValidateAccountRequest:
+      type: object
+      required:
+        - bank_code
+        - account_number
+      properties:
+        bank_code:
+          type: string
+          pattern: ^[0-9]{3}$
+        account_number:
+          type: string
+    WithdrawalRequest:
+      type: object
+      required:
+        - amount
+        - account_no
+        - bank_code
+        - currency
+        - request_id
+      properties:
+        amount:
+          type: integer
+          minimum: 1
+        account_no:
+          type: string
+        bank_code:
+          type: string
+          pattern: ^[0-9]{3}$
+        currency:
+          type: string
+          minLength: 3
+          maxLength: 3
+        description:
+          type: string
+        request_id:
+          type: string
+          format: uuid
+    WithdrawalResponse:
+      type: object
+      properties:
+        id:
+          type: string
+        status:
+          type: string
+tags: []

--- a/readme.md
+++ b/readme.md
@@ -14,10 +14,12 @@ Run `npm run reconcile-balances` after setting database environment variables to
 
 ## API Documentation
 
-Generate and serve Swagger docs for payment and withdrawal routes:
+Generate and serve Swagger docs for payment, withdrawal, and withdrawal S2S routes:
 
 ```bash
 npm run docs
 ```
 
-This command writes `docs/api/payment.yaml` and `docs/api/withdrawal.yaml` and hosts them at `http://localhost:3001/docs/payment` and `/docs/withdrawal`.
+This command writes `docs/api/payment.yaml`, `docs/api/withdrawal.yaml`, and `docs/api/withdrawal.s2s.yaml` and hosts them at `http://localhost:3001/docs/payment`, `/docs/withdrawal`, and `/docs/withdrawal-s2s`.
+
+S2S withdrawal requests must include `X-API-Key`, `X-Timestamp`, and `X-Signature` headers and originate from an IP address whitelisted under the `s2s_ip_whitelist` setting.

--- a/scripts/docs.ts
+++ b/scripts/docs.ts
@@ -21,9 +21,11 @@ const genSpec = (title: string, apis: string[], out: string) => {
 
 const paymentSpec = genSpec('Payment API', ['src/route/payment.routes.ts'], 'payment.yaml')
 const withdrawalSpec = genSpec('Withdrawal API', ['src/route/withdrawals.routes.ts'], 'withdrawal.yaml')
+const withdrawalS2SSpec = genSpec('Withdrawal S2S API', ['src/route/withdrawals.s2s.routes.ts'], 'withdrawal.s2s.yaml')
 
 app.use('/docs/payment', swaggerUi.serveFiles(paymentSpec), swaggerUi.setup(paymentSpec))
 app.use('/docs/withdrawal', swaggerUi.serveFiles(withdrawalSpec), swaggerUi.setup(withdrawalSpec))
+app.use('/docs/withdrawal-s2s', swaggerUi.serveFiles(withdrawalS2SSpec), swaggerUi.setup(withdrawalS2SSpec))
 
 const port = Number(process.env.DOCS_PORT) || 3001
 app.listen(port, () => {

--- a/src/app.ts
+++ b/src/app.ts
@@ -45,6 +45,7 @@ import { oyTransactionCallback, gidiTransactionCallback } from './controller/pay
 import merchantDashRoutes from './route/merchant/dashboard.routes';
 import clientWebRoutes from './route/client/web.routes';    // partner-client routes
 import withdrawalRoutes from './route/withdrawals.routes';  // add withdrawal routes
+import withdrawalS2SRoutes from './route/withdrawals.s2s.routes';
 
 import apiKeyAuth from './middleware/apiKeyAuth';
 import { authMiddleware } from './middleware/auth';
@@ -138,6 +139,7 @@ app.get('/ops/ifp-status', (_req, res) => {
 
 // Routes ringan lain
 app.use('/api/v1/withdrawals', withdrawalRoutes);
+app.use('/api/v1/withdrawals/s2s', withdrawalS2SRoutes);
 app.use('/api/v1', bankRoutes);
 
 /* ========== 1. PUBLIC ROUTES ========== */

--- a/src/middleware/ipWhitelist.ts
+++ b/src/middleware/ipWhitelist.ts
@@ -1,29 +1,46 @@
 import { Request, Response, NextFunction } from 'express';
 import { prisma } from '../core/prisma';
 
-let whitelist: string[] | null = null;
+let adminWhitelist: string[] | null = null;
+let s2sWhitelist: string[] | null = null;
 
-async function fetchWhitelist() {
-  const row = await prisma.setting.findUnique({
-    where: { key: 'admin_ip_whitelist' },
-  });
-  whitelist = row?.value
-    .split(',')
-    .map(ip => ip.trim())
-    .filter(Boolean) ?? [];
+async function fetchWhitelist(key: string): Promise<string[]> {
+  const row = await prisma.setting.findUnique({ where: { key } });
+  return (
+    row?.value
+      .split(',')
+      .map(ip => ip.trim())
+      .filter(Boolean) ?? []
+  );
 }
 
 export async function refreshAdminIpWhitelist() {
-  await fetchWhitelist();
+  adminWhitelist = await fetchWhitelist('admin_ip_whitelist');
+}
+
+export async function refreshS2SIpWhitelist() {
+  s2sWhitelist = await fetchWhitelist('s2s_ip_whitelist');
 }
 
 export async function adminIpWhitelist(req: Request, res: Response, next: NextFunction) {
-  if (whitelist === null) {
-    await fetchWhitelist();
+  if (adminWhitelist === null) {
+    await refreshAdminIpWhitelist();
   }
   const header = (req.headers['x-forwarded-for'] as string) || req.socket.remoteAddress || '';
   const ip = header.split(',')[0].trim();
-  if ((whitelist?.length ?? 0) > 0 && !whitelist!.includes(ip)) {
+  if ((adminWhitelist?.length ?? 0) > 0 && !adminWhitelist!.includes(ip)) {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+  next();
+}
+
+export async function s2sIpWhitelist(req: Request, res: Response, next: NextFunction) {
+  if (s2sWhitelist === null) {
+    await refreshS2SIpWhitelist();
+  }
+  const header = (req.headers['x-forwarded-for'] as string) || req.socket.remoteAddress || '';
+  const ip = header.split(',')[0].trim();
+  if ((s2sWhitelist?.length ?? 0) > 0 && !s2sWhitelist!.includes(ip)) {
     return res.status(403).json({ error: 'Forbidden' });
   }
   next();

--- a/src/middleware/verifySignature.ts
+++ b/src/middleware/verifySignature.ts
@@ -1,0 +1,35 @@
+import { Response, NextFunction } from 'express'
+import crypto from 'crypto'
+import { prisma } from '../core/prisma'
+import { ApiKeyRequest } from './apiKeyAuth'
+
+export async function verifySignature(
+  req: ApiKeyRequest,
+  res: Response,
+  next: NextFunction
+) {
+  const clientId = req.clientId
+  const ts = req.header('X-Timestamp') || ''
+  const gotSig = req.header('X-Signature') || ''
+  if (!clientId || !ts || !gotSig) {
+    return res.status(401).json({ error: 'Missing signature headers' })
+  }
+  const client = await prisma.partnerClient.findUnique({
+    where: { id: clientId },
+    select: { apiSecret: true },
+  })
+  if (!client) {
+    return res.status(401).json({ error: 'Client not found' })
+  }
+  const rawBody = (req as any).rawBody || ''
+  const path = req.originalUrl.split('?')[0]
+  const payload = `${req.method}:${path}:${ts}:${rawBody}`
+  const expected = crypto
+    .createHmac('sha256', client.apiSecret)
+    .update(payload)
+    .digest('hex')
+  if (!crypto.timingSafeEqual(Buffer.from(expected), Buffer.from(gotSig))) {
+    return res.status(401).json({ error: 'Invalid signature' })
+  }
+  next()
+}

--- a/src/route/withdrawals.s2s.routes.ts
+++ b/src/route/withdrawals.s2s.routes.ts
@@ -1,0 +1,131 @@
+import express, { Router } from 'express'
+import apiKeyAuth from '../middleware/apiKeyAuth'
+import { verifySignature } from '../middleware/verifySignature'
+import { s2sIpWhitelist } from '../middleware/ipWhitelist'
+import {
+  requestWithdrawS2S,
+  listWithdrawalsS2S,
+  validateAccountS2S,
+} from '../controller/withdrawals.controller'
+
+/**
+ * @openapi
+ * components:
+ *   securitySchemes:
+ *     apiKeyAuth:
+ *       type: apiKey
+ *       in: header
+ *       name: X-API-Key
+ *   schemas:
+ *     ValidateAccountRequest:
+ *       type: object
+ *       required:
+ *         - bank_code
+ *         - account_number
+ *       properties:
+ *         bank_code:
+ *           type: string
+ *           pattern: '^[0-9]{3}$'
+ *         account_number:
+ *           type: string
+ *     WithdrawalRequest:
+ *       type: object
+ *       required:
+ *         - amount
+ *         - account_no
+ *         - bank_code
+ *         - currency
+ *         - request_id
+ *       properties:
+ *         amount:
+ *           type: integer
+ *           minimum: 1
+ *         account_no:
+ *           type: string
+ *         bank_code:
+ *           type: string
+ *           pattern: '^[0-9]{3}$'
+ *         currency:
+ *           type: string
+ *           minLength: 3
+ *           maxLength: 3
+ *         description:
+ *           type: string
+ *         request_id:
+ *           type: string
+ *           format: uuid
+ *     WithdrawalResponse:
+ *       type: object
+ *       properties:
+ *         id:
+ *           type: string
+ *         status:
+ *           type: string
+ */
+
+const router = Router()
+
+router.use(apiKeyAuth, s2sIpWhitelist, verifySignature)
+
+router.post('/withdrawals', express.json(), requestWithdrawS2S)
+/**
+ * @openapi
+ * /withdrawals:
+ *   post:
+ *     summary: Create a new withdrawal
+ *     security:
+ *       - apiKeyAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/WithdrawalRequest'
+ *     responses:
+ *       200:
+ *         description: Withdrawal created
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/WithdrawalResponse'
+ */
+
+router.get('/withdrawals', listWithdrawalsS2S)
+/**
+ * @openapi
+ * /withdrawals:
+ *   get:
+ *     summary: List all withdrawals for this client
+ *     security:
+ *       - apiKeyAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: ref
+ *         schema:
+ *           type: string
+ *         description: Filter by partial reference ID (case-insensitive)
+ *     responses:
+ *       200:
+ *         description: List of withdrawals
+ */
+
+router.post('/withdrawals/validate-account', express.json(), validateAccountS2S)
+/**
+ * @openapi
+ * /withdrawals/validate-account:
+ *   post:
+ *     summary: Validate destination account
+ *     security:
+ *       - apiKeyAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/ValidateAccountRequest'
+ *     responses:
+ *       200:
+ *         description: Account validated
+ */
+
+export default router


### PR DESCRIPTION
## Summary
- add server-to-server withdrawal routes secured by API key, HMAC signature, and IP whitelist
- support listing and account validation for S2S withdrawals
- document new S2S withdrawal API

## Testing
- `npm test`
- `npm run docs`


------
https://chatgpt.com/codex/tasks/task_e_68c7ed88d4ac83288e1326aaa040b4dd