### PR TITLE
Add global IP whitelist middleware and admin endpoints

### DIFF
--- a/docs/services/admin.md
+++ b/docs/services/admin.md
@@ -4,7 +4,9 @@ Administrative endpoints require an authenticated admin account.
 
 ## Endpoints
 - `GET /api/v1/admin/ip-whitelist` – retrieve allowed IP addresses for admin operations.
-- `PUT /api/v1/admin/ip-whitelist` – update the IP whitelist with `{ "ips": ["1.1.1.1"] }`.
+- `PUT /api/v1/admin/ip-whitelist` – update the admin IP whitelist with `{ "ips": ["1.1.1.1"] }`.
+- `GET /api/v1/admin/ip-whitelist/global` – retrieve IPs allowed to access any API route.
+- `PUT /api/v1/admin/ip-whitelist/global` – update the global whitelist with the same `{ "ips": ["1.1.1.1"] }` payload. Requires a super admin token.
 
 ## Reconcile Partner Balances
 - Script: `npm run reconcile-balances` recomputes balances from settled orders and withdrawals.

--- a/src/app.ts
+++ b/src/app.ts
@@ -49,6 +49,7 @@ import withdrawalS2SRoutes from './route/withdrawals.s2s.routes';
 
 import apiKeyAuth from './middleware/apiKeyAuth';
 import { authMiddleware } from './middleware/auth';
+import { globalIpWhitelist } from './middleware/ipWhitelist';
 
 import { config } from './config';
 import logger from './logger';
@@ -121,6 +122,7 @@ app.get('/api/v1/qris/:orderId', proxyOyQris);
 
 // Global middleware
 app.set('trust proxy', 1);
+app.use(globalIpWhitelist);
 app.use(helmet());
 app.use(rateLimit({
   windowMs: 60_000,

--- a/src/controller/admin/ipWhitelist.controller.ts
+++ b/src/controller/admin/ipWhitelist.controller.ts
@@ -1,17 +1,23 @@
 import { Response } from 'express';
 import { prisma } from '../../core/prisma';
 import { AuthRequest } from '../../middleware/auth';
-import { refreshAdminIpWhitelist } from '../../middleware/ipWhitelist';
+import { refreshAdminIpWhitelist, refreshGlobalIpWhitelist } from '../../middleware/ipWhitelist';
 import { logAdminAction } from '../../util/adminLog';
+
+function parseIps(value?: string | null): string[] {
+  return (
+    value
+      ?.split(',')
+      .map(ip => ip.trim())
+      .filter(Boolean) ?? []
+  );
+}
 
 export async function getIpWhitelist(_req: AuthRequest, res: Response) {
   const row = await prisma.setting.findUnique({
     where: { key: 'admin_ip_whitelist' },
   });
-  const ips = row?.value
-    .split(',')
-    .map(ip => ip.trim())
-    .filter(Boolean) ?? [];
+  const ips = parseIps(row?.value);
   res.json({ data: ips });
 }
 
@@ -28,6 +34,31 @@ export async function updateIpWhitelist(req: AuthRequest, res: Response) {
   await refreshAdminIpWhitelist();
   if (req.userId) {
     await logAdminAction(req.userId, 'updateIpWhitelist', 'admin_ip_whitelist', ips);
+  }
+  res.json({ data: ips });
+}
+
+export async function getGlobalIpWhitelist(_req: AuthRequest, res: Response) {
+  const row = await prisma.setting.findUnique({
+    where: { key: 'global_ip_whitelist' },
+  });
+  const ips = parseIps(row?.value);
+  res.json({ data: ips });
+}
+
+export async function updateGlobalIpWhitelist(req: AuthRequest, res: Response) {
+  const ips: string[] = Array.isArray(req.body.ips)
+    ? req.body.ips.map((ip: string) => ip.trim()).filter(Boolean)
+    : [];
+  const value = ips.join(',');
+  await prisma.setting.upsert({
+    where: { key: 'global_ip_whitelist' },
+    update: { value },
+    create: { key: 'global_ip_whitelist', value },
+  });
+  await refreshGlobalIpWhitelist();
+  if (req.userId) {
+    await logAdminAction(req.userId, 'updateGlobalIpWhitelist', 'global_ip_whitelist', ips);
   }
   res.json({ data: ips });
 }

--- a/src/middleware/ipWhitelist.ts
+++ b/src/middleware/ipWhitelist.ts
@@ -3,15 +3,32 @@ import { prisma } from '../core/prisma';
 
 let adminWhitelist: string[] | null = null;
 let s2sWhitelist: string[] | null = null;
+let globalWhitelist: string[] | null = null;
 
-async function fetchWhitelist(key: string): Promise<string[]> {
-  const row = await prisma.setting.findUnique({ where: { key } });
+function parseWhitelist(value?: string | null): string[] {
   return (
-    row?.value
-      .split(',')
+    value
+      ?.split(',')
       .map(ip => ip.trim())
       .filter(Boolean) ?? []
   );
+}
+
+async function fetchWhitelist(key: string): Promise<string[]> {
+  const row = await prisma.setting.findUnique({ where: { key } });
+  if (!row) {
+    try {
+      await prisma.setting.create({ data: { key, value: '' } });
+      return [];
+    } catch (error: any) {
+      if (error?.code === 'P2002' || error?.code === 11000) {
+        const existing = await prisma.setting.findUnique({ where: { key } });
+        return parseWhitelist(existing?.value);
+      }
+      throw error;
+    }
+  }
+  return parseWhitelist(row.value);
 }
 
 export async function refreshAdminIpWhitelist() {
@@ -20,6 +37,10 @@ export async function refreshAdminIpWhitelist() {
 
 export async function refreshS2SIpWhitelist() {
   s2sWhitelist = await fetchWhitelist('s2s_ip_whitelist');
+}
+
+export async function refreshGlobalIpWhitelist() {
+  globalWhitelist = await fetchWhitelist('global_ip_whitelist');
 }
 
 export async function adminIpWhitelist(req: Request, res: Response, next: NextFunction) {
@@ -46,4 +67,15 @@ export async function s2sIpWhitelist(req: Request, res: Response, next: NextFunc
   next();
 }
 
+export async function globalIpWhitelist(req: Request, res: Response, next: NextFunction) {
+  if (globalWhitelist === null) {
+    await refreshGlobalIpWhitelist();
+  }
+  const header = (req.headers['x-forwarded-for'] as string) || req.socket.remoteAddress || '';
+  const ip = header.split(',')[0].trim();
+  if ((globalWhitelist?.length ?? 0) > 0 && !globalWhitelist!.includes(ip)) {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+  next();
+}
 

--- a/src/route/admin/ipWhitelist.routes.ts
+++ b/src/route/admin/ipWhitelist.routes.ts
@@ -1,6 +1,11 @@
 import { Router } from 'express';
 import { requireSuperAdminAuth } from '../../middleware/auth';
-import { getIpWhitelist, updateIpWhitelist } from '../../controller/admin/ipWhitelist.controller';
+import {
+  getGlobalIpWhitelist,
+  getIpWhitelist,
+  updateGlobalIpWhitelist,
+  updateIpWhitelist,
+} from '../../controller/admin/ipWhitelist.controller';
 
 const router = Router();
 
@@ -8,6 +13,8 @@ router.use(requireSuperAdminAuth);
 
 router.get('/', getIpWhitelist);
 router.put('/', updateIpWhitelist);
+router.get('/global', getGlobalIpWhitelist);
+router.put('/global', updateGlobalIpWhitelist);
 
 export default router;
 

--- a/test/helpers/testEnv.ts
+++ b/test/helpers/testEnv.ts
@@ -1,0 +1,6 @@
+process.env.JWT_SECRET = process.env.JWT_SECRET ?? 'test-secret'
+
+const globalForPrisma = globalThis as unknown as { prisma?: any }
+if (!globalForPrisma.prisma) {
+  globalForPrisma.prisma = {}
+}

--- a/test/ipWhitelist.routes.test.ts
+++ b/test/ipWhitelist.routes.test.ts
@@ -1,38 +1,68 @@
-import test from 'node:test'
+import './helpers/testEnv'
+import test, { beforeEach } from 'node:test'
 import assert from 'node:assert/strict'
 import express from 'express'
 import request from 'supertest'
 import jwt from 'jsonwebtoken'
 
 import router from '../src/route/admin/ipWhitelist.routes'
-import { adminIpWhitelist, refreshAdminIpWhitelist } from '../src/middleware/ipWhitelist'
+import {
+  adminIpWhitelist,
+  globalIpWhitelist,
+  refreshAdminIpWhitelist,
+  refreshGlobalIpWhitelist,
+} from '../src/middleware/ipWhitelist'
 import { config } from '../src/config'
 import { prisma } from '../src/core/prisma'
 
-let currentSetting: { key: string; value: string | null } | null = {
-  key: 'admin_ip_whitelist',
-  value: '1.1.1.1',
-}
+type SettingRow = { key: string; value: string }
+
+let settings: Record<string, SettingRow | undefined> = {}
+
+const uniqueError = () => Object.assign(new Error('Unique constraint'), { code: 'P2002' })
 
 ;(prisma as any).setting = {
-  findUnique: async () => currentSetting,
-  upsert: async ({ where, update, create }: any) => {
-    const value = update?.value ?? create?.value
-    currentSetting = { key: where.key, value }
-    return currentSetting
+  findUnique: async ({ where: { key } }: any) => settings[key] ?? null,
+  upsert: async ({ where: { key }, update, create }: any) => {
+    const value =
+      typeof update?.value === 'string'
+        ? update.value
+        : typeof create?.value === 'string'
+          ? create.value
+          : ''
+    settings[key] = { key, value }
+    return settings[key]
+  },
+  create: async ({ data }: any) => {
+    if (settings[data.key]) {
+      throw uniqueError()
+    }
+    settings[data.key] = { key: data.key, value: data.value }
+    return settings[data.key]
   },
 }
 ;(prisma as any).adminLog = { create: async () => {} }
+;(prisma as any).partnerUser = { findUnique: async () => null }
 
 const app = express()
 app.use(express.json())
+app.use(globalIpWhitelist)
 app.use('/admin/ip-whitelist', router)
 app.get('/secure', adminIpWhitelist, (_req, res) => res.json({ ok: true }))
+app.get('/public', (_req, res) => res.json({ ok: true }))
 
 const superToken = jwt.sign({ sub: '1', role: 'SUPER_ADMIN' }, config.api.jwtSecret)
 
-test('get and update whitelist and enforce middleware', async () => {
+beforeEach(async () => {
+  settings = {
+    admin_ip_whitelist: { key: 'admin_ip_whitelist', value: '1.1.1.1' },
+    global_ip_whitelist: { key: 'global_ip_whitelist', value: '' },
+  }
   await refreshAdminIpWhitelist()
+  await refreshGlobalIpWhitelist()
+})
+
+test('get and update whitelist and enforce middleware', async () => {
   let res = await request(app)
     .get('/admin/ip-whitelist')
     .set('Authorization', `Bearer ${superToken}`)
@@ -57,10 +87,44 @@ test('get and update whitelist and enforce middleware', async () => {
   assert.equal(res.status, 403)
 })
 
-test('empty whitelist allows all', async () => {
-  currentSetting = { key: 'admin_ip_whitelist', value: '' }
+test('empty admin whitelist allows all', async () => {
+  settings['admin_ip_whitelist'] = { key: 'admin_ip_whitelist', value: '' }
   await refreshAdminIpWhitelist()
   const res = await request(app).get('/secure').set('X-Forwarded-For', '5.5.5.5')
   assert.equal(res.status, 200)
 })
 
+test('global whitelist routes control all traffic', async () => {
+  let res = await request(app)
+    .get('/admin/ip-whitelist/global')
+    .set('Authorization', `Bearer ${superToken}`)
+  assert.deepEqual(res.body, { data: [] })
+
+  res = await request(app).get('/public').set('X-Forwarded-For', '8.8.8.8')
+  assert.equal(res.status, 200)
+
+  res = await request(app)
+    .put('/admin/ip-whitelist/global')
+    .set('Authorization', `Bearer ${superToken}`)
+    .send({ ips: ['9.9.9.9'] })
+  assert.equal(res.status, 200)
+  assert.deepEqual(res.body, { data: ['9.9.9.9'] })
+
+  res = await request(app)
+    .get('/admin/ip-whitelist/global')
+    .set('Authorization', `Bearer ${superToken}`)
+    .set('X-Forwarded-For', '9.9.9.9')
+  assert.deepEqual(res.body, { data: ['9.9.9.9'] })
+
+  res = await request(app).get('/public').set('X-Forwarded-For', '9.9.9.9')
+  assert.equal(res.status, 200)
+  res = await request(app).get('/public').set('X-Forwarded-For', '8.8.8.8')
+  assert.equal(res.status, 403)
+})
+
+test('refreshGlobalIpWhitelist creates missing setting', async () => {
+  delete settings['global_ip_whitelist']
+  await refreshGlobalIpWhitelist()
+  assert.equal(settings['global_ip_whitelist']?.key, 'global_ip_whitelist')
+  assert.equal(settings['global_ip_whitelist']?.value, '')
+})


### PR DESCRIPTION
## Summary
- add middleware that seeds missing whitelist settings and enforces the new global IP allow list on every request
- expose controller routes and docs so super admins can manage the global IP whitelist
- expand tests with environment helpers to cover both admin and global whitelist behavior

## Testing
- npm test *(fails: Node test runner does not expand the glob pattern `test/**/*.test.ts`)*
- node --test -r ts-node/register test/ipWhitelist.routes.test.ts


------
https://chatgpt.com/codex/tasks/task_e_68c8e5cfba60832883077e165d082081