### PR TITLE
Add global IP whitelist controls for super admin

### DIFF
--- a/frontend/src/components/layouts/AdminLayout.tsx
+++ b/frontend/src/components/layouts/AdminLayout.tsx
@@ -16,6 +16,7 @@ import {
   Banknote,
   Wrench,
   Wallet,
+  Globe,
 } from 'lucide-react'
 import { motion } from 'framer-motion'
 
@@ -34,6 +35,7 @@ const navItems = [
   { label: 'Settlement',        href: '/admin/settlement', Icon: Banknote },
   { label: 'Settlement Adjust', href: '/admin/settlement-adjust', Icon: Wrench },
   { label: 'Logs',              href: '/admin/logs',       Icon: FileText },
+  { label: 'IP Whitelist',      href: '/super-admin/ip-whitelist', Icon: Globe },
 ]
 
 // aktif juga untuk child paths

--- a/frontend/src/pages/super-admin/ip-whitelist.tsx
+++ b/frontend/src/pages/super-admin/ip-whitelist.tsx
@@ -7,30 +7,74 @@ import { useRequireAuth } from '@/hooks/useAuth'
 export default function IpWhitelistPage() {
   useRequireAuth()
   const [ips, setIps] = useState('')
+  const [globalIps, setGlobalIps] = useState('')
   const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
   const [error, setError] = useState('')
 
   useEffect(() => {
-    api
-      .get<{ data: string[] }>('/admin/ip-whitelist')
-      .then(res => setIps(res.data.data.join(', ')))
-      .catch(() => setError('Failed to load'))
+    Promise.all([
+      api.get<{ data: string[] }>('/admin/ip-whitelist'),
+      api.get<{ data: string[] }>('/admin/ip-whitelist/global'),
+    ])
+      .then(([localRes, globalRes]) => {
+        setIps(localRes.data.data.join(', '))
+        setGlobalIps(globalRes.data.data.join(', '))
+      })
+      .catch((e: any) => {
+        setError(e.response?.data?.error || 'Failed to load IP whitelists')
+      })
       .finally(() => setLoading(false))
   }, [])
 
   const save = async () => {
-    setLoading(true)
-    setError('')
-    try {
-      const arr = ips
+    const parseIps = (value: string) =>
+      value
         .split(',')
         .map(ip => ip.trim())
         .filter(Boolean)
-      await api.put('/admin/ip-whitelist', { ips: arr })
+
+    const isValidIp = (ip: string) => {
+      const segments = ip.split('.')
+      if (segments.length !== 4) return false
+      return segments.every(segment => {
+        if (!/^\d+$/.test(segment)) return false
+        const num = Number(segment)
+        return num >= 0 && num <= 255
+      })
+    }
+
+    const localIps = parseIps(ips)
+    const globalIpsList = parseIps(globalIps)
+
+    const invalidLocal = localIps.filter(ip => !isValidIp(ip))
+    const invalidGlobal = globalIpsList.filter(ip => !isValidIp(ip))
+
+    if (invalidLocal.length || invalidGlobal.length) {
+      const messages = [] as string[]
+      if (invalidLocal.length) {
+        messages.push(`Local: ${invalidLocal.join(', ')}`)
+      }
+      if (invalidGlobal.length) {
+        messages.push(`Global: ${invalidGlobal.join(', ')}`)
+      }
+      setError(`Invalid IP address format — ${messages.join(' | ')}`)
+      return
+    }
+
+    setSaving(true)
+    setError('')
+    try {
+      await Promise.all([
+        api.put('/admin/ip-whitelist', { ips: localIps }),
+        api.put('/admin/ip-whitelist/global', { ips: globalIpsList }),
+      ])
+      setIps(localIps.join(', '))
+      setGlobalIps(globalIpsList.join(', '))
     } catch (e: any) {
-      setError(e.response?.data?.error || 'Failed to save')
+      setError(e.response?.data?.error || 'Failed to save IP whitelists')
     } finally {
-      setLoading(false)
+      setSaving(false)
     }
   }
 
@@ -40,15 +84,28 @@ export default function IpWhitelistPage() {
     <div style={{ padding: '1rem' }}>
       <h1>IP Whitelist</h1>
       {error && <div style={{ color: 'red' }}>{error}</div>}
-      <textarea
-        value={ips}
-        onChange={e => setIps(e.target.value)}
-        rows={4}
-        style={{ width: '100%', marginBottom: '1rem' }}
-        placeholder="Comma separated IPs"
-      />
-      <button onClick={save} disabled={loading}>
-        {loading ? 'Saving…' : 'Save'}
+      <label style={{ display: 'block', marginBottom: '1rem' }}>
+        <div style={{ fontWeight: 600, marginBottom: '0.5rem' }}>Merchant IP Whitelist</div>
+        <textarea
+          value={ips}
+          onChange={e => setIps(e.target.value)}
+          rows={4}
+          style={{ width: '100%' }}
+          placeholder="Comma separated IPv4 addresses"
+        />
+      </label>
+      <label style={{ display: 'block', marginBottom: '1rem' }}>
+        <div style={{ fontWeight: 600, marginBottom: '0.5rem' }}>Global IP Whitelist</div>
+        <textarea
+          value={globalIps}
+          onChange={e => setGlobalIps(e.target.value)}
+          rows={4}
+          style={{ width: '100%' }}
+          placeholder="Comma separated IPv4 addresses"
+        />
+      </label>
+      <button onClick={save} disabled={saving}>
+        {saving ? 'Saving…' : 'Save'}
       </button>
     </div>
   )


### PR DESCRIPTION
## Summary
- extend the super admin IP whitelist screen to manage both merchant and global allow lists
- validate IP address format, surface backend errors, and persist updates through the existing API helper
- expose the screen from the admin navigation for easy access

## Testing
- npm run lint *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c8e9d1626883288da568e78fe6241f