### PR TITLE
Handle ING1 callbacks and fallback reconciliation

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -39,8 +39,12 @@ import bankRoutes from './route/bank.routes'
 import { proxyOyQris } from './controller/qr.controller'
 
 // import disbursementRouter from './route/disbursement.routes';
-import paymentController, { transactionCallback } from './controller/payment';
-import { oyTransactionCallback, gidiTransactionCallback } from './controller/payment'
+import paymentController, {
+  transactionCallback,
+  oyTransactionCallback,
+  gidiTransactionCallback,
+  ing1TransactionCallback,
+} from './controller/payment'
 
 import merchantDashRoutes from './route/merchant/dashboard.routes';
 import clientWebRoutes from './route/client/web.routes';    // partner-client routes
@@ -114,6 +118,8 @@ app.post(
   express.json(),
   gidiTransactionCallback
 );
+
+app.get('/api/v1/transaction/callback/ing1', ing1TransactionCallback);
 
 app.post('/api/v1/transaction/callback/oy', oyTransactionCallback);
 

--- a/src/service/ing1Fallback.ts
+++ b/src/service/ing1Fallback.ts
@@ -1,0 +1,118 @@
+import logger from '../logger';
+import { prisma } from '../core/prisma';
+import { Ing1Client, Ing1Config } from './ing1Client';
+import { parseIng1Date, parseIng1Number, processIng1Update } from './ing1Status';
+
+interface FallbackOptions {
+  reff?: string | null;
+  clientReff?: string | null;
+}
+
+const BACKOFF_MINUTES = [3, 10, 40];
+
+interface WatcherState {
+  attempts: number;
+  timer?: NodeJS.Timeout;
+}
+
+const watchers = new Map<string, WatcherState>();
+
+function scheduleNext(orderId: string, state: WatcherState, delayMs: number, runner: () => void) {
+  if (state.timer) {
+    clearTimeout(state.timer);
+  }
+  state.timer = setTimeout(runner, delayMs);
+  watchers.set(orderId, state);
+}
+
+export function cancelIng1Fallback(orderId: string) {
+  const state = watchers.get(orderId);
+  if (state?.timer) {
+    clearTimeout(state.timer);
+  }
+  watchers.delete(orderId);
+}
+
+export function scheduleIng1Fallback(
+  orderId: string,
+  cfg: Ing1Config,
+  opts: FallbackOptions = {}
+) {
+  if (!orderId) return;
+  if (watchers.has(orderId)) return;
+
+  const client = new Ing1Client(cfg);
+  const state: WatcherState = { attempts: 0 };
+
+  const runCheck = async () => {
+    try {
+      const existingCallback = await prisma.transaction_callback.findFirst({
+        where: { referenceId: orderId },
+      });
+      if (existingCallback) {
+        cancelIng1Fallback(orderId);
+        return;
+      }
+
+      const order = await prisma.order.findUnique({
+        where: { id: orderId },
+        select: {
+          status: true,
+          pgRefId: true,
+          pgClientRef: true,
+        },
+      });
+
+      if (!order || order.status !== 'PENDING') {
+        cancelIng1Fallback(orderId);
+        return;
+      }
+
+      const reff = opts.reff ?? order.pgRefId ?? undefined;
+      const clientReff = opts.clientReff ?? order.pgClientRef ?? orderId;
+
+      if (!reff) {
+        cancelIng1Fallback(orderId);
+        return;
+      }
+
+      const resp = await client.checkCashin({ reff, clientReff });
+      if (resp.status === 'PAID' || resp.status === 'FAILED') {
+        const data = resp.data ?? {};
+        await processIng1Update({
+          orderId,
+          rc: resp.rc,
+          statusText: (data.status as string) ?? resp.status,
+          billerReff: resp.reff ?? reff,
+          clientReff: resp.clientReff ?? clientReff,
+          grossAmount:
+            parseIng1Number(data.total ?? data.amount ?? data.gross_amount ?? data.grossAmount) ?? undefined,
+          paymentReceivedTime:
+            parseIng1Date(data.paid_at ?? data.payment_received_time ?? data.paidAt) ?? undefined,
+          settlementTime:
+            parseIng1Date(data.settlement_time ?? data.settled_at ?? data.settlementTime) ?? undefined,
+          expirationTime:
+            parseIng1Date(data.expired_at ?? data.expiration_time ?? data.expirationTime) ?? undefined,
+        });
+        cancelIng1Fallback(orderId);
+        return;
+      }
+    } catch (err: any) {
+      logger.error(`[ing1Fallback] error for ${orderId}: ${err.message}`);
+    }
+
+    state.attempts += 1;
+    if (state.attempts >= BACKOFF_MINUTES.length) {
+      cancelIng1Fallback(orderId);
+      return;
+    }
+
+    const delayMs = BACKOFF_MINUTES[state.attempts] * 60 * 1000;
+    scheduleNext(orderId, state, delayMs, runCheck);
+  };
+
+  watchers.set(orderId, state);
+  const initialDelay = BACKOFF_MINUTES[0] * 60 * 1000;
+  scheduleNext(orderId, state, initialDelay, runCheck);
+  logger.info(`[ing1Fallback] scheduled watcher for ${orderId}`);
+}

--- a/src/service/ing1Status.ts
+++ b/src/service/ing1Status.ts
@@ -1,0 +1,243 @@
+import crypto from 'crypto';
+import moment from 'moment-timezone';
+import logger from '../logger';
+import { prisma } from '../core/prisma';
+import { computeSettlement } from './feeSettlement';
+import { isJakartaWeekend, wibTimestamp, wibTimestampString } from '../util/time';
+
+export type Ing1InternalStatus = 'PAID' | 'PENDING' | 'FAILED';
+
+const normalizeNumber = (value: unknown): number | null => {
+  if (value == null) return null;
+  const raw = Array.isArray(value) ? value[0] : value;
+  if (typeof raw === 'number') {
+    return Number.isFinite(raw) ? raw : null;
+  }
+  if (typeof raw === 'string') {
+    const cleaned = raw.replace(/,/g, '').trim();
+    if (!cleaned) return null;
+    const parsed = Number(cleaned);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+};
+
+const normalizeRc = (rc?: number | null): Ing1InternalStatus | null => {
+  if (rc == null || Number.isNaN(rc)) return null;
+  if (rc === 0) return 'PAID';
+  if (rc === 91) return 'PENDING';
+  if (rc === 99) return 'FAILED';
+  return null;
+};
+
+const normalizeStatusText = (status?: string | null): Ing1InternalStatus | null => {
+  if (!status) return null;
+  const lowered = status.toLowerCase();
+  if (['success', 'paid', 'complete', 'completed', 'done'].includes(lowered)) {
+    return 'PAID';
+  }
+  if (['pending', 'process', 'processing'].includes(lowered)) {
+    return 'PENDING';
+  }
+  if (['failed', 'fail', 'cancel', 'cancelled', 'expired', 'reject', 'rejected', 'void'].includes(lowered)) {
+    return 'FAILED';
+  }
+  return null;
+};
+
+export const mapIng1Status = (
+  rc?: number | null,
+  statusText?: string | null
+): Ing1InternalStatus => {
+  const byRc = normalizeRc(rc);
+  if (byRc) return byRc;
+  const byText = normalizeStatusText(statusText);
+  if (byText) return byText;
+  return 'FAILED';
+};
+
+export const parseIng1Date = (value: unknown): Date | null => {
+  if (value == null) return null;
+  const raw = Array.isArray(value) ? value[0] : value;
+  if (!raw) return null;
+  if (raw instanceof Date) {
+    return Number.isNaN(raw.getTime()) ? null : raw;
+  }
+  if (typeof raw !== 'string') return null;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+
+  const normalized = trimmed.replace('T', ' ');
+  const formats = [
+    'YYYY-MM-DD HH:mm:ss',
+    'YYYY-MM-DD HH:mm:ssZ',
+    'YYYY-MM-DDTHH:mm:ssZ',
+  ];
+
+  for (const fmt of formats) {
+    const parsed = moment.tz(normalized, fmt, 'Asia/Jakarta');
+    if (parsed.isValid()) return parsed.toDate();
+  }
+
+  const fallback = moment.tz(trimmed, 'Asia/Jakarta');
+  if (fallback.isValid()) return fallback.toDate();
+
+  const jsDate = new Date(trimmed);
+  return Number.isNaN(jsDate.getTime()) ? null : jsDate;
+};
+
+export const parseIng1Number = (value: unknown): number | null => normalizeNumber(value);
+
+export interface Ing1UpdatePayload {
+  orderId: string;
+  rc?: number | null;
+  statusText?: string | null;
+  billerReff?: string | null;
+  clientReff?: string | null;
+  grossAmount?: number | null;
+  paymentReceivedTime?: Date | null | undefined;
+  settlementTime?: Date | null | undefined;
+  expirationTime?: Date | null | undefined;
+}
+
+export interface Ing1UpdateResult {
+  newStatus: string;
+  previousStatus: string;
+  forwarded: boolean;
+}
+
+export async function processIng1Update(payload: Ing1UpdatePayload): Promise<Ing1UpdateResult> {
+  const { orderId } = payload;
+  if (!orderId) throw new Error('Missing orderId for ING1 update');
+
+  const order = await prisma.order.findUnique({
+    where: { id: orderId },
+    select: {
+      id: true,
+      userId: true,
+      amount: true,
+      feeLauncx: true,
+      pendingAmount: true,
+      qrPayload: true,
+      status: true,
+    },
+  });
+
+  if (!order) {
+    throw new Error(`Order ${orderId} not found for ING1 update`);
+  }
+
+  const previousStatus = order.status;
+  if (previousStatus === 'SETTLED') {
+    logger.info(`[ING1] Order ${orderId} already settled; skipping update`);
+    return { newStatus: previousStatus, previousStatus, forwarded: false };
+  }
+
+  const rc = payload.rc != null ? Number(payload.rc) : null;
+  const mappedStatus = mapIng1Status(rc, payload.statusText);
+  const isSuccess = mappedStatus === 'PAID';
+
+  let settlementStatus = payload.statusText?.toUpperCase() || null;
+  if (!settlementStatus) {
+    settlementStatus = isSuccess ? 'PENDING' : 'FAILED';
+  }
+
+  const grossAmount =
+    payload.grossAmount != null && !Number.isNaN(payload.grossAmount)
+      ? payload.grossAmount
+      : order.amount;
+
+  const partner = await prisma.partnerClient.findUnique({
+    where: { id: order.userId },
+    select: {
+      feePercent: true,
+      feeFlat: true,
+      weekendFeePercent: true,
+      weekendFeeFlat: true,
+      callbackUrl: true,
+      callbackSecret: true,
+    },
+  });
+
+  if (!partner) {
+    throw new Error(`PartnerClient ${order.userId} not found for ING1 update`);
+  }
+
+  const weekend = isJakartaWeekend(payload.paymentReceivedTime ?? new Date());
+  const pctFee = weekend ? partner.weekendFeePercent ?? 0 : partner.feePercent ?? 0;
+  const flatFee = weekend ? partner.weekendFeeFlat ?? 0 : partner.feeFlat ?? 0;
+  const { fee: feeLauncx, settlement } = computeSettlement(grossAmount, {
+    percent: pctFee,
+    flat: flatFee,
+  });
+
+  const pendingAmount = isSuccess ? settlement : null;
+
+  const updateData: any = {
+    status: mappedStatus,
+    settlementStatus,
+    fee3rdParty: 0,
+    feeLauncx: isSuccess ? feeLauncx : null,
+    pendingAmount,
+    settlementAmount: isSuccess ? null : grossAmount,
+    updatedAt: wibTimestamp(),
+  };
+
+  if (payload.paymentReceivedTime !== undefined) {
+    updateData.paymentReceivedTime = payload.paymentReceivedTime;
+  }
+  if (payload.settlementTime !== undefined) {
+    updateData.settlementTime = payload.settlementTime;
+  }
+  if (payload.expirationTime !== undefined) {
+    updateData.trxExpirationTime = payload.expirationTime;
+  }
+  if (payload.billerReff) {
+    updateData.pgRefId = payload.billerReff;
+  }
+  if (payload.clientReff) {
+    updateData.pgClientRef = payload.clientReff;
+  }
+
+  await prisma.order.update({
+    where: { id: orderId },
+    data: updateData,
+  });
+
+  let forwarded = false;
+  if (isSuccess && previousStatus !== 'PAID' && partner.callbackUrl && partner.callbackSecret) {
+    const updated = await prisma.order.findUnique({ where: { id: orderId } });
+    if (updated) {
+      const timestamp = wibTimestampString();
+      const nonce = crypto.randomUUID();
+      const payloadToSend = {
+        orderId,
+        status: mappedStatus,
+        settlementStatus,
+        grossAmount: updated.amount,
+        feeLauncx: updated.feeLauncx,
+        netAmount: updated.pendingAmount,
+        qrPayload: updated.qrPayload,
+        timestamp,
+        nonce,
+      };
+      const signature = crypto
+        .createHmac('sha256', partner.callbackSecret)
+        .update(JSON.stringify(payloadToSend))
+        .digest('hex');
+
+      await prisma.callbackJob.create({
+        data: {
+          url: partner.callbackUrl,
+          payload: payloadToSend,
+          signature,
+          partnerClientId: updated.userId,
+        },
+      });
+      forwarded = true;
+      logger.info('[ING1] Enqueued callback to partner');
+    }
+  }
+
+  return { newStatus: mappedStatus, previousStatus, forwarded };
+}


### PR DESCRIPTION
## Summary
- expose a GET /api/v1/transaction/callback/ing1 endpoint wired to a new ING1 callback handler
- implement ING1 callback processing to upsert callback records, update orders, and forward successful notifications
- add ING1 status utilities, integrate a fallback scheduler, and extend status checks to requery pending ING1 orders

## Testing
- npm run build *(fails: repository lacks generated Prisma client types such as DisbursementStatus/InputJsonValue)*

------
https://chatgpt.com/codex/tasks/task_e_68d2afac98308328a7a295fe969cd92f