### PR TITLE
feat: add ING1 cash-out support

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -24,7 +24,7 @@ import usersRoutes from './route/users.routes';
 import settingsRoutes   from './route/settings.routes';
 import { loadWeekendOverrideDates } from './util/time'
 
-import { withdrawalCallback } from './controller/withdrawals.controller'
+import { withdrawalCallback, ing1WithdrawalCallback } from './controller/withdrawals.controller'
 import pivotCallbackRouter from './route/payment.callback.routes';
 
 import webRoutes from './route/web.routes';
@@ -107,6 +107,8 @@ app.post(
   }),
   withdrawalCallback           // ⛔ TANPA express.json()
 );
+
+app.get('/api/v1/withdrawals/callback/ing1', ing1WithdrawalCallback);
 
 app.post(
   '/api/v1/transaction/callback/gidi',


### PR DESCRIPTION
## Summary
- extend the ING1 client with cash-out inquiry, payment, check, and history helpers
- update withdrawal validation and execution paths to support ING1 including callback and fallback handlers
- wire the new ING1 payout callback route in the express app

## Testing
- npm run build
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68d3686f781c8328af269a69019c9e77