### PR TITLE
feat(admin): allow configuring ING1 sub merchants

### DIFF
--- a/src/controller/admin/merchant.controller.ts
+++ b/src/controller/admin/merchant.controller.ts
@@ -888,7 +888,7 @@ export const getDashboardSummary = async (req: Request, res: Response) => {
     const subs = await prisma.sub_merchant.findMany({
       where: {
         ...(merchantId && merchantId !== 'all' ? { merchantId } : {}),
-        provider: { in: ['hilogate', 'oy', 'gidi'] },
+        provider: { in: ['hilogate', 'oy', 'gidi', 'ing1'] },
         ...(subMerchantId && subMerchantId !== 'all'
           ? { id: String(subMerchantId) }
           : {}),
@@ -1005,7 +1005,7 @@ export const getMerchantBalances = async (req: Request, res: Response) => {
       const subs = await prisma.sub_merchant.findMany({
         where: {
           ...(merchantId && merchantId !== 'all' ? { merchantId } : {}),
-          provider: { in: ['hilogate', 'oy', 'gidi'] },
+          provider: { in: ['hilogate', 'oy', 'gidi', 'ing1'] },
         },
         select: { id: true, name: true, provider: true, credentials: true },
       });

--- a/src/controller/admin/subMerchant.controller.ts
+++ b/src/controller/admin/subMerchant.controller.ts
@@ -11,7 +11,7 @@ const scheduleSchema = z.object({
 });
 const nameSchema = z.string().min(1)
 
-const providerSchema = z.enum(['hilogate', 'oy', 'netzme', '2c2p', 'gidi']);
+const providerSchema = z.enum(['hilogate', 'oy', 'netzme', '2c2p', 'gidi', 'ing1']);
 
 // GET /admin/merchant/:merchantId/pg
 export async function listSubMerchants(req: Request, res: Response) {


### PR DESCRIPTION
## Summary
- add a dedicated ING1 credential schema and parsing so the backend accepts Billers configuration cleanly
- include ING1 in admin sub-merchant provider validation and dashboard queries
- extend the admin merchant settings UI to capture and display ING1 credential fields alongside existing providers

## Testing
- npm run build *(fails: prisma types not generated for DisbursementStatus/InputJsonValue in existing codebase)*
- cd frontend && npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2991576dc83289ccf70388efa84e9