### PR TITLE
Allow super admins to access admin settings

### DIFF
--- a/src/route/settings.routes.ts
+++ b/src/route/settings.routes.ts
@@ -1,14 +1,11 @@
 // src/route/settings.routes.ts
-import { Router, Request, Response, NextFunction } from 'express';
+import { Router } from 'express';
 import { getSettings, updateSettings } from '../controller/settings.controller';
 
-import { authMiddleware }      from '../middleware/auth';
+import { requireAdminAuth } from '../middleware/auth';
 
 const router = Router();
-router.use(authMiddleware, (req: Request, res: Response, next: NextFunction) => {
-  if ((req as any).userRole !== 'ADMIN') return res.status(403).end();
-  next();
-});
+router.use(...requireAdminAuth);
 // GET  /api/v1/settings
 router.get('/', getSettings);
 

--- a/test/settings.routes.test.ts
+++ b/test/settings.routes.test.ts
@@ -1,8 +1,13 @@
-import test from 'node:test'
+import './helpers/testEnv'
+
+import test, { beforeEach } from 'node:test'
 import assert from 'node:assert/strict'
 import express from 'express'
 import request from 'supertest'
+import jwt from 'jsonwebtoken'
 
+import settingsRoutes from '../src/route/settings.routes'
+import { config } from '../src/config'
 import { prisma } from '../src/core/prisma'
 import * as adminLog from '../src/util/adminLog'
 
@@ -13,8 +18,25 @@ settlement.restartSettlementChecker = (expr: string) => { lastCron = expr }
 
 const { updateSettings } = require('../src/controller/settings.controller')
 
+type SettingRow = { key: string; value: string }
+
+let settingsStore: Record<string, SettingRow> = {}
+
+const resetSettingsStore = (initial: Record<string, string> = {}) => {
+  settingsStore = {}
+  for (const [key, value] of Object.entries(initial)) {
+    settingsStore[key] = { key, value }
+  }
+}
+
 ;(prisma as any).setting = {
-  upsert: async ({ where, update, create }: any) => ({ key: where.key, value: update?.value ?? create?.value })
+  findMany: async () => Object.values(settingsStore),
+  upsert: async ({ where, update, create }: any) => {
+    const value = update?.value ?? create?.value ?? ''
+    const row = { key: where.key, value }
+    settingsStore[where.key] = row
+    return row
+  }
 }
 ;(prisma as any).$transaction = async (ops: any[]) => Promise.all(ops)
 ;(adminLog as any).logAdminAction = async () => {}
@@ -24,6 +46,16 @@ app.use(express.json())
 app.put('/settings', (req, res) => {
   ;(req as any).userId = 'admin1'
   updateSettings(req as any, res)
+})
+
+const adminApp = express()
+adminApp.use(express.json())
+adminApp.use('/api/v1/admin/settings', settingsRoutes)
+
+const superToken = jwt.sign({ sub: 'super-1', role: 'SUPER_ADMIN' }, config.api.jwtSecret)
+
+beforeEach(() => {
+  resetSettingsStore()
 })
 
 test('accepts valid cron expression', async () => {
@@ -41,4 +73,27 @@ test('rejects invalid cron expression', async () => {
 test('rejects sub-minute cron expression', async () => {
   const res = await request(app).put('/settings').send({ settlement_cron: '*/30 * * * * *' })
   assert.equal(res.status, 400)
+})
+
+test('SUPER_ADMIN token can read admin settings', async () => {
+  resetSettingsStore({ example: 'value' })
+  const res = await request(adminApp)
+    .get('/api/v1/admin/settings')
+    .set('Authorization', `Bearer ${superToken}`)
+
+  assert.equal(res.status, 200)
+  assert.equal(res.body.data.example, 'value')
+  assert.equal(res.body.data.settlement_cron, '0 16 * * *')
+})
+
+test('SUPER_ADMIN token can update admin settings', async () => {
+  lastCron = null
+  const res = await request(adminApp)
+    .put('/api/v1/admin/settings')
+    .set('Authorization', `Bearer ${superToken}`)
+    .send({ settlement_cron: '0 15 * * *' })
+
+  assert.equal(res.status, 200)
+  assert.equal(lastCron, '0 15 * * *')
+  assert.equal(settingsStore['settlement_cron']?.value, '0 15 * * *')
 })


### PR DESCRIPTION
## Summary
- replace the settings router guard with `requireAdminAuth` so ADMIN and SUPER_ADMIN tokens are accepted
- add integration coverage that exercises the admin settings endpoints with a SUPER_ADMIN JWT

## Testing
- node --test -r ts-node/register test/settings.routes.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d604940f0c8328b5b9baad94c76b22