### PR TITLE
Add concurrency-limited callback worker processing

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -35,10 +35,11 @@ export const config = {
       intervalMs: Number(process.env.HTTP_RETRY_INTERVAL_MS) || 1000,
     },
 
-        callbackQueue: {
+    callbackQueue: {
       intervalMs: Number(process.env.CALLBACK_WORKER_INTERVAL_MS) || 5000,
       maxAttempts: Number(process.env.CALLBACK_WORKER_MAX_ATTEMPTS) || 3,
       batchSize: Number(process.env.CALLBACK_WORKER_BATCH_SIZE) || 10,
+      concurrency: Number(process.env.CALLBACK_WORKER_CONCURRENCY) || 5,
     },
     expectedApiKey:
       process.env.EXPECTED_API_KEY || 'a240f00aba8cdb2d8622ae778fa36598',

--- a/src/worker/callbackQueue.ts
+++ b/src/worker/callbackQueue.ts
@@ -3,6 +3,78 @@ import { postWithRetry } from '../utils/postWithRetry'
 import logger from '../logger'
 import { config } from '../config'
 
+async function handleCallbackJob(job: Awaited<ReturnType<typeof prisma.callbackJob.findFirst>>) {
+  if (!job) return
+
+  try {
+    await postWithRetry(
+      job.url,
+      job.payload,
+      {
+        headers: { 'X-Callback-Signature': job.signature },
+        timeout: 5000,
+      },
+      3
+    )
+    await prisma.callbackJob.update({
+      where: { id: job.id },
+      data: {
+        delivered: true,
+        attempts: job.attempts + 1,
+        lastError: null,
+        responseBody: null,
+      },
+    })
+    logger.info(`[callbackQueue] delivered job ${job.id}`)
+  } catch (err: any) {
+    const attempts = job.attempts + 1
+    const statusCode = err?.response?.status
+    const isRateLimited = statusCode === 429
+    const isClientError =
+      statusCode >= 400 && statusCode < 500 && !isRateLimited
+    const maxAttemptsReached =
+      attempts >= config.api.callbackQueue.maxAttempts
+
+    if (isClientError || maxAttemptsReached) {
+      await prisma.callbackJobDeadLetter.create({
+        data: {
+          jobId: job.id,
+          partnerClientId: job.partnerClientId,
+          url: job.url,
+          payload: job.payload,
+          signature: job.signature,
+          statusCode,
+          errorMessage: err.message,
+          responseBody: err.response?.data ?? null,
+          attempts,
+        },
+      })
+      await prisma.callbackJob.delete({ where: { id: job.id } })
+      logger.error(
+        `[callbackQueue] moved job ${job.id} to dead-letter queue: ${err.message}`
+      )
+    } else {
+      const lastError = {
+        statusCode: statusCode ?? null,
+        message: err?.message ?? 'Unknown error',
+        timestamp: new Date().toISOString(),
+      }
+
+      await prisma.callbackJob.update({
+        where: { id: job.id },
+        data: {
+          attempts,
+          lastError,
+          responseBody: err.response?.data ?? null,
+        },
+      })
+      logger.error(
+        `[callbackQueue] delivery failed for job ${job.id}: ${err.message}`
+      )
+    }
+  }
+}
+
 export async function processCallbackJobs() {
   const jobs = await prisma.callbackJob.findMany({
     where: {
@@ -13,74 +85,24 @@ export async function processCallbackJobs() {
     take: config.api.callbackQueue.batchSize,
   })
 
+  const concurrency = Math.max(1, config.api.callbackQueue.concurrency)
+  const executing: Promise<void>[] = []
+
   for (const job of jobs) {
-    try {
-      await postWithRetry(
-        job.url,
-        job.payload,
-        {
-          headers: { 'X-Callback-Signature': job.signature },
-          timeout: 5000,
-        },
-        3
-      )
-      await prisma.callbackJob.update({
-        where: { id: job.id },
-        data: {
-          delivered: true,
-          attempts: job.attempts + 1,
-          lastError: null,
-          responseBody: null,
-        },
-      })
-      logger.info(`[callbackQueue] delivered job ${job.id}`)
-    } catch (err: any) {
-      const attempts = job.attempts + 1
-      const statusCode = err?.response?.status
-      const isRateLimited = statusCode === 429
-      const isClientError =
-        statusCode >= 400 && statusCode < 500 && !isRateLimited
-      const maxAttemptsReached =
-        attempts >= config.api.callbackQueue.maxAttempts
-
-      if (isClientError || maxAttemptsReached) {
-        await prisma.callbackJobDeadLetter.create({
-          data: {
-            jobId: job.id,
-            partnerClientId: job.partnerClientId,
-            url: job.url,
-            payload: job.payload,
-            signature: job.signature,
-            statusCode,
-            errorMessage: err.message,
-            responseBody: err.response?.data ?? null,
-            attempts,
-          },
-        })
-        await prisma.callbackJob.delete({ where: { id: job.id } })
-        logger.error(
-          `[callbackQueue] moved job ${job.id} to dead-letter queue: ${err.message}`
-        )
-      } else {
-        const lastError = {
-          statusCode: statusCode ?? null,
-          message: err?.message ?? 'Unknown error',
-          timestamp: new Date().toISOString(),
-        }
-
-        await prisma.callbackJob.update({
-          where: { id: job.id },
-          data: {
-            attempts,
-            lastError,
-            responseBody: err.response?.data ?? null,
-          },
-        })
-        logger.error(
-          `[callbackQueue] delivery failed for job ${job.id}: ${err.message}`
-        )
+    const task = handleCallbackJob(job).finally(() => {
+      const index = executing.indexOf(task)
+      if (index !== -1) {
+        executing.splice(index, 1)
       }
+    })
+    executing.push(task)
+    if (executing.length >= concurrency) {
+      await Promise.race(executing)
     }
+  }
+
+  if (executing.length > 0) {
+    await Promise.allSettled(executing)
   }
 }
 

--- a/test/callbackQueue.worker.test.ts
+++ b/test/callbackQueue.worker.test.ts
@@ -6,6 +6,7 @@ import assert from 'node:assert/strict'
 import type { AxiosResponse } from 'axios'
 
 import { processCallbackJobs } from '../src/worker/callbackQueue'
+import { config } from '../src/config'
 import * as postWithRetryModule from '../src/utils/postWithRetry'
 import { prisma } from '../src/core/prisma'
 
@@ -111,3 +112,155 @@ test('callback jobs are retried after rate limiting', async (t) => {
   assert.equal(jobDeleted, false)
   assert.equal(job.lastError, null)
 })
+
+test(
+  'callback jobs respect concurrency limit and dead-letter failures',
+  async (t) => {
+    const originalConcurrency = config.api.callbackQueue.concurrency
+    config.api.callbackQueue.concurrency = 2
+
+    const jobs = new Map([
+      [
+        'job-success-1',
+        {
+          id: 'job-success-1',
+          url: 'https://example.com/callback-1',
+          payload: { id: 'job-success-1' },
+          signature: 'signature-1',
+          attempts: 0,
+          delivered: false,
+          partnerClientId: 'partner-1',
+          lastError: null as any,
+          responseBody: null as any,
+          createdAt: new Date(1),
+        },
+      ],
+      [
+        'job-failure',
+        {
+          id: 'job-failure',
+          url: 'https://example.com/callback-2',
+          payload: { id: 'job-failure' },
+          signature: 'signature-2',
+          attempts: 0,
+          delivered: false,
+          partnerClientId: 'partner-2',
+          lastError: null as any,
+          responseBody: null as any,
+          createdAt: new Date(2),
+        },
+      ],
+      [
+        'job-success-2',
+        {
+          id: 'job-success-2',
+          url: 'https://example.com/callback-3',
+          payload: { id: 'job-success-2' },
+          signature: 'signature-3',
+          attempts: 0,
+          delivered: false,
+          partnerClientId: 'partner-3',
+          lastError: null as any,
+          responseBody: null as any,
+          createdAt: new Date(3),
+        },
+      ],
+    ])
+
+    const deadLetterEntries: any[] = []
+    let active = 0
+    let maxActive = 0
+
+    const delays: Record<string, number> = {
+      'job-success-1': 30,
+      'job-failure': 40,
+      'job-success-2': 10,
+    }
+
+    const postWithRetryMock = mock.method(
+      postWithRetryModule,
+      'postWithRetry',
+      async (_url, payload: { id: string }) => {
+        active += 1
+        maxActive = Math.max(maxActive, active)
+
+        const jobId = payload.id
+
+        return new Promise((resolve, reject) => {
+          setTimeout(() => {
+            active -= 1
+            if (jobId === 'job-failure') {
+              const error: any = new Error('Bad Request')
+              error.response = { status: 400, data: { error: 'bad request' } }
+              reject(error)
+            } else {
+              resolve({
+                status: 200,
+                statusText: 'OK',
+                data: { success: true },
+                headers: {},
+                config: {} as any,
+              } as AxiosResponse)
+            }
+          }, delays[jobId])
+        })
+      }
+    )
+
+    const originalFindMany = prisma.callbackJob.findMany
+    const originalUpdate = prisma.callbackJob.update
+    const originalDelete = prisma.callbackJob.delete
+    const originalDeadLetterCreate = prisma.callbackJobDeadLetter.create
+
+    ;(prisma.callbackJob as any).findMany = async () => {
+      return Array.from(jobs.values())
+        .filter((job: any) => !job.delivered)
+        .map((job: any) => ({ ...job }))
+    }
+
+    ;(prisma.callbackJob as any).update = async ({ where, data }: any) => {
+      const job = jobs.get(where.id)
+      if (!job) return null
+
+      if (typeof data.attempts === 'number') {
+        job.attempts = data.attempts
+      }
+      if (Object.prototype.hasOwnProperty.call(data, 'delivered')) {
+        job.delivered = data.delivered
+      }
+      if (Object.prototype.hasOwnProperty.call(data, 'lastError')) {
+        job.lastError = data.lastError
+      }
+      if (Object.prototype.hasOwnProperty.call(data, 'responseBody')) {
+        job.responseBody = data.responseBody
+      }
+      return { ...job }
+    }
+
+    ;(prisma.callbackJob as any).delete = async ({ where }: any) => {
+      jobs.delete(where.id)
+    }
+
+    ;(prisma.callbackJobDeadLetter as any).create = async ({ data }: any) => {
+      deadLetterEntries.push(data)
+    }
+
+    t.after(() => {
+      postWithRetryMock.mock.restore()
+      ;(prisma.callbackJob as any).findMany = originalFindMany
+      ;(prisma.callbackJob as any).update = originalUpdate
+      ;(prisma.callbackJob as any).delete = originalDelete
+      ;(prisma.callbackJobDeadLetter as any).create = originalDeadLetterCreate
+      config.api.callbackQueue.concurrency = originalConcurrency
+    })
+
+    await processCallbackJobs()
+
+    assert.equal(maxActive, 2, 'should run jobs in parallel up to limit')
+    assert.equal(jobs.get('job-success-1')?.delivered, true)
+    assert.equal(jobs.get('job-success-2')?.delivered, true)
+    assert.equal(jobs.get('job-failure'), undefined, 'failed job should be removed')
+    assert.equal(deadLetterEntries.length, 1)
+    assert.equal(deadLetterEntries[0].jobId, 'job-failure')
+  }
+)


### PR DESCRIPTION
## Summary
- replace the sequential callback processing loop with a concurrency-limited dispatcher while preserving retry and dead-letter handling
- introduce a configurable callback worker concurrency setting and environment variable for controlling parallelism
- expand callback worker tests to cover parallel execution and dead-letter behavior under concurrency

## Testing
- node --test -r ts-node/register test/callbackQueue.worker.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d60df3f7f08328bb05bdbcc16d7936