### PR TITLE
Add client API error logging and expose in client UI

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -54,6 +54,7 @@ import withdrawalS2SRoutes from './route/withdrawals.s2s.routes';
 import apiKeyAuth from './middleware/apiKeyAuth';
 import { authMiddleware } from './middleware/auth';
 import { globalIpWhitelist } from './middleware/ipWhitelist';
+import { clientApiLogger } from './middleware/clientApiLogger';
 
 import { config } from './config';
 import logger from './logger';
@@ -192,7 +193,7 @@ app.use('/api/v1/admin/ip-whitelist', authMiddleware, adminIpWhitelistRoutes);
 app.use('/api/v1/admin/settlement', authMiddleware, adminSettlementRoutes);
 
 /* ========== 4. PARTNER-CLIENT ========== */
-app.use('/api/v1/client', clientWebRoutes);
+app.use('/api/v1/client', clientApiLogger, clientWebRoutes);
 
 /* ========== 5. MERCHANT DASHBOARD ========== */
 app.use('/api/v1/merchant/dashboard', authMiddleware, merchantDashRoutes);

--- a/src/controller/clientApiLog.controller.ts
+++ b/src/controller/clientApiLog.controller.ts
@@ -2,19 +2,46 @@ import { Response } from 'express'
 import { prisma } from '../core/prisma'
 import { ClientAuthRequest } from '../middleware/clientAuth'
 
+type LogOrigin = 'callback-job' | 'callback-dead-letter' | 'client-request'
+
+interface NormalisedLog {
+  id: string
+  origin: LogOrigin
+  url: string | null
+  method: string | null
+  path: string | null
+  statusCode: number | null
+  errorMessage: string | null
+  responseBody: string | null
+  payload: string | null
+  createdAt: Date
+  respondedAt: Date | null
+}
+
 export async function getClientApiLogs(req: ClientAuthRequest, res: Response) {
-  const { page = '1', limit = '50' } = req.query as Record<string, any>
+  const { page = '1', limit = '50', date_from, date_to, success } = req.query as Record<string, any>
   const pageNum = Math.max(1, parseInt(String(page), 10))
   const pageSize = Math.min(100, parseInt(String(limit), 10))
 
   const skip = (pageNum - 1) * pageSize
   const take = pageSize + skip
 
+  const dateFrom = parseDate(date_from)
+  const dateTo = parseDate(date_to)
+  const statusFilter = parseStatusFilter(success)
+
   const allowed = [req.partnerClientId!, ...(req.childrenIds ?? [])]
 
-  const [jobs, deadLetters, totalJobs, totalDeadLetters] = await Promise.all([
+  const createdAtFilter = buildDateFilter(dateFrom, dateTo)
+
+  const baseCallbackWhere = {
+    partnerClientId: { in: allowed },
+    ...(createdAtFilter ? { createdAt: createdAtFilter } : {}),
+  }
+
+  const [jobs, deadLetters, requestLogs] = await Promise.all([
     prisma.callbackJob.findMany({
-      where: { partnerClientId: { in: allowed } },
+      where: baseCallbackWhere,
       orderBy: { createdAt: 'desc' },
       take,
       select: {
@@ -29,7 +56,7 @@ export async function getClientApiLogs(req: ClientAuthRequest, res: Response) {
       },
     }),
     prisma.callbackJobDeadLetter.findMany({
-      where: { partnerClientId: { in: allowed } },
+      where: baseCallbackWhere,
       orderBy: { createdAt: 'desc' },
       take,
       select: {
@@ -42,38 +69,74 @@ export async function getClientApiLogs(req: ClientAuthRequest, res: Response) {
         responseBody: true,
       },
     }),
-    prisma.callbackJob.count({ where: { partnerClientId: { in: allowed } } }),
-    prisma.callbackJobDeadLetter.count({ where: { partnerClientId: { in: allowed } } }),
+    prisma.clientApiRequestLog.findMany({
+      where: {
+        partnerClientId: { in: allowed },
+        ...(createdAtFilter ? { createdAt: createdAtFilter } : {}),
+      },
+      orderBy: { createdAt: 'desc' },
+      take,
+      select: {
+        id: true,
+        method: true,
+        path: true,
+        statusCode: true,
+        errorMessage: true,
+        responseBody: true,
+        payload: true,
+        createdAt: true,
+      },
+    }),
   ])
 
-  const merged = [
-    ...jobs.map(j => ({
+  const merged: NormalisedLog[] = [
+    ...jobs.map((j): NormalisedLog => ({
       id: j.id,
+      origin: 'callback-job',
       url: j.url,
-      status: j.delivered ? 'DELIVERED' : 'PENDING',
-      attempts: j.attempts,
+      method: null,
+      path: null,
+      statusCode: normaliseStatusCode(j.delivered, j.lastError),
+      errorMessage: normaliseError(j.delivered, j.lastError),
+      responseBody: normaliseResponseBody(j.responseBody),
+      payload: null,
       createdAt: j.createdAt,
       respondedAt: j.delivered ? j.updatedAt : null,
-      statusCode: (j.lastError as any)?.statusCode ?? (j.delivered ? 200 : null),
-      errorMessage: (j.lastError as any)?.message ?? null,
-      responseBody: normaliseResponseBody(j.responseBody),
     })),
-    ...deadLetters.map(d => ({
+    ...deadLetters.map((d): NormalisedLog => ({
       id: d.id,
+      origin: 'callback-dead-letter',
       url: d.url,
-      status: 'FAILED',
-      attempts: d.attempts,
-      createdAt: d.createdAt,
-      respondedAt: d.createdAt,
+      method: null,
+      path: null,
       statusCode: d.statusCode ?? null,
       errorMessage: d.errorMessage ?? null,
       responseBody: normaliseResponseBody(d.responseBody),
+      payload: null,
+      createdAt: d.createdAt,
+      respondedAt: d.createdAt,
+    })),
+    ...requestLogs.map((r): NormalisedLog => ({
+      id: r.id,
+      origin: 'client-request',
+      url: null,
+      method: r.method,
+      path: r.path,
+      statusCode: r.statusCode,
+      errorMessage: r.errorMessage ?? null,
+      responseBody: r.responseBody ?? null,
+      payload: normaliseResponseBody(r.payload),
+      createdAt: r.createdAt,
+      respondedAt: null,
     })),
   ]
 
   merged.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
-  const rows = merged.slice(skip, skip + pageSize)
-  const total = totalJobs + totalDeadLetters
+
+  const filtered = merged.filter(row => applyStatusFilter(row, statusFilter))
+
+  const rows = filtered.slice(skip, skip + pageSize)
+  const total = filtered.length
 
   return res.json({ rows, total })
 }
@@ -86,4 +149,47 @@ function normaliseResponseBody(body: unknown) {
   } catch {
     return String(body)
   }
+}
+
+function normaliseStatusCode(delivered: boolean, lastError: unknown): number | null {
+  if (delivered) return 200
+  const status = (lastError as any)?.statusCode
+  if (typeof status === 'number') return status
+  return null
+}
+
+function normaliseError(delivered: boolean, lastError: unknown): string | null {
+  if (delivered) return null
+  const message = (lastError as any)?.message ?? (lastError as any)?.error
+  if (typeof message === 'string') return message
+  return null
+}
+
+function parseDate(value: unknown): Date | undefined {
+  if (typeof value !== 'string' || value.trim() === '') return undefined
+  const d = new Date(value)
+  return Number.isNaN(d.getTime()) ? undefined : d
+}
+
+type StatusFilter = 'success' | 'failure' | null
+
+function parseStatusFilter(value: unknown): StatusFilter {
+  if (typeof value !== 'string') return null
+  if (value === 'true') return 'success'
+  if (value === 'false') return 'failure'
+  return null
+}
+
+function buildDateFilter(from?: Date, to?: Date) {
+  const filter: { gte?: Date; lte?: Date } = {}
+  if (from) filter.gte = from
+  if (to) filter.lte = to
+  return Object.keys(filter).length ? filter : null
+}
+
+function applyStatusFilter(log: NormalisedLog, filter: StatusFilter): boolean {
+  if (!filter) return true
+  if (log.statusCode == null) return filter === 'failure'
+  if (filter === 'success') return log.statusCode >= 200 && log.statusCode < 400
+  return log.statusCode >= 400
 }

--- a/src/middleware/clientApiLogger.ts
+++ b/src/middleware/clientApiLogger.ts
@@ -1,0 +1,103 @@
+import { NextFunction, Response } from 'express';
+import { Prisma } from '@prisma/client';
+import { prisma } from '../core/prisma';
+import logger from '../logger';
+import { ClientAuthRequest } from './clientAuth';
+
+type JsonValue = Prisma.JsonValue;
+
+function safeJson(value: unknown): JsonValue | null {
+  if (value == null) return null;
+  if (typeof value === 'object') {
+    try {
+      JSON.stringify(value);
+      return value as JsonValue;
+    } catch {
+      return String(value);
+    }
+  }
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return value;
+  }
+  return String(value);
+}
+
+function serialiseBody(body: unknown): string | null {
+  if (body == null) return null;
+  if (typeof body === 'string') return body;
+  try {
+    return JSON.stringify(body);
+  } catch {
+    return String(body);
+  }
+}
+
+function extractErrorMessage(body: unknown, statusMessage?: string): string | null {
+  if (!body) return statusMessage ?? null;
+  if (typeof body === 'string') return body.slice(0, 500);
+  if (typeof body === 'object') {
+    const maybeMessage = (body as any)?.message ?? (body as any)?.error ?? (body as any)?.errors;
+    if (typeof maybeMessage === 'string') return maybeMessage.slice(0, 500);
+  }
+  return statusMessage ?? null;
+}
+
+function collectPayload(req: ClientAuthRequest): JsonValue | null {
+  const payload: Record<string, unknown> = {};
+  const hasBody = req.body && typeof req.body === 'object' && Object.keys(req.body).length > 0;
+  if (hasBody) payload.body = req.body;
+
+  const queryKeys = Object.keys(req.query ?? {});
+  if (queryKeys.length > 0) payload.query = req.query;
+
+  if ('rawBody' in req && !hasBody) {
+    const raw = (req as any).rawBody;
+    if (raw) payload.rawBody = raw;
+  }
+
+  if (Object.keys(payload).length === 0) return null;
+  return safeJson(payload);
+}
+
+export function clientApiLogger(req: ClientAuthRequest, res: Response, next: NextFunction) {
+  let responseBody: unknown;
+
+  const originalJson = res.json.bind(res);
+  res.json = (body: any) => {
+    responseBody = body;
+    return originalJson(body);
+  };
+
+  const originalSend = res.send.bind(res);
+  res.send = (body: any) => {
+    responseBody = body;
+    return originalSend(body);
+  };
+
+  res.on('finish', async () => {
+    if (!req.partnerClientId) return;
+    if (res.statusCode < 400) return;
+
+    try {
+      await prisma.clientApiRequestLog.create({
+        data: {
+          partnerClientId: req.partnerClientId,
+          method: req.method,
+          path: req.originalUrl || req.path,
+          statusCode: res.statusCode,
+          errorMessage: extractErrorMessage(responseBody, res.statusMessage ?? undefined) ?? undefined,
+          payload: collectPayload(req) ?? undefined,
+          responseBody: serialiseBody(responseBody) ?? undefined,
+        },
+      });
+    } catch (err) {
+      if (err instanceof Error) {
+        logger.error('Failed to persist client API log', { err });
+      } else {
+        logger.error('Failed to persist client API log', { err: String(err) });
+      }
+    }
+  });
+
+  next();
+}

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -200,6 +200,7 @@ model PartnerClient {
   forceSchedule      String?
   callbackJobs       CallbackJob[]
   callbackJobDeadLetters CallbackJobDeadLetter[]
+  clientApiRequestLogs ClientApiRequestLog[]
 }
 
 model Order {
@@ -392,4 +393,20 @@ model HilogateCallbackWatcher {
   attemptCount Int      @default(0)
   processed    Boolean  @default(false)
   nextRetryAt  DateTime
+}
+
+model ClientApiRequestLog {
+  id              String         @id @default(auto()) @map("_id") @db.ObjectId
+  partnerClientId String
+  partnerClient   PartnerClient  @relation(fields: [partnerClientId], references: [id])
+  method          String
+  path            String
+  statusCode      Int
+  errorMessage    String?
+  payload         Json?
+  responseBody    String?
+  createdAt       DateTime       @default(now())
+
+  @@index([partnerClientId, createdAt])
+  @@map("client_api_request_log")
 }


### PR DESCRIPTION
## Summary
- add a Mongo-backed ClientApiRequestLog model and wire it to PartnerClient relations
- log failing partner-client REST requests via a new middleware before the client routes
- merge request logs with callback logs in the client API log controller and surface origin metadata to the frontend table

## Testing
- pnpm prisma db push --schema=src/prisma/schema.prisma *(hangs locally without MongoDB, interrupted after waiting)*
- pnpm generate
- pnpm tsc -p tsconfig.backend.json

------
https://chatgpt.com/codex/tasks/task_e_68d62c5886248328ae6dac9f990ca9b4