### PR TITLE
Add pagination controls to client API logs

### DIFF
--- a/src/controller/clientApiLog.controller.ts
+++ b/src/controller/clientApiLog.controller.ts
@@ -20,8 +20,11 @@ interface NormalisedLog {
 
 export async function getClientApiLogs(req: ClientAuthRequest, res: Response) {
   const { page = '1', limit = '50', date_from, date_to, success } = req.query as Record<string, any>
-  const pageNum = Math.max(1, parseInt(String(page), 10))
-  const pageSize = Math.min(100, parseInt(String(limit), 10))
+  const parsedPage = Number.parseInt(String(page), 10)
+  const parsedLimit = Number.parseInt(String(limit), 10)
+
+  const pageNum = Number.isNaN(parsedPage) ? 1 : Math.max(1, parsedPage)
+  const pageSize = Number.isNaN(parsedLimit) ? 50 : Math.max(1, Math.min(100, parsedLimit))
 
   const skip = (pageNum - 1) * pageSize
   const take = pageSize + skip


### PR DESCRIPTION
## Summary
- add pagination state and controls to the client API log page, including page size selection and total tracking
- send page and limit parameters with API requests and reuse the response total to drive pagination
- harden the getClientApiLogs controller to validate page/limit inputs so pagination respects client-specified bounds

## Testing
- npm test *(fails: Could not find '/workspace/launcxbaru/test/**/*.test.ts')*


------
https://chatgpt.com/codex/tasks/task_e_68d62fa8c434832884332b8f21eda619