### PR TITLE
Add Piro payment provider integration

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -134,6 +134,13 @@ oy: {
       apiKey: process.env.PAYMENT_API_KEY || '',
       apiSecret: process.env.PAYMENT_API_SECRET || '',
     },
+    piro: {
+      baseUrl: process.env.PIRO_BASE_URL || '',
+      clientId: process.env.PIRO_CLIENT_ID || '',
+      clientSecret: process.env.PIRO_CLIENT_SECRET || '',
+      signatureKey: process.env.PIRO_SIGNATURE_KEY || '',
+      callbackUrl: process.env.PIRO_CALLBACK_URL || '',
+    },
   },
   aws: {
     region: process.env.AWS_REGION || 'ap-southeast-1',

--- a/src/route/payment.routes.ts
+++ b/src/route/payment.routes.ts
@@ -192,6 +192,11 @@ paymentRouter.post(
   '/transaction/callback/gidi',
   paymentController.gidiTransactionCallback,
 )
+
+paymentRouter.post(
+  '/transaction/callback/piro',
+  paymentController.piroTransactionCallback,
+)
 /**
  * @openapi
  * /transaction/callback/gidi:

--- a/src/service/piroClient.ts
+++ b/src/service/piroClient.ts
@@ -1,0 +1,262 @@
+import axios, { AxiosInstance } from 'axios'
+import crypto from 'crypto'
+import logger from '../logger'
+
+export interface PiroConfig {
+  baseUrl: string
+  clientId: string
+  clientSecret: string
+  signatureKey: string
+  merchantId: string
+  storeId?: string
+  terminalId?: string
+  channel?: string
+  callbackUrl?: string
+}
+
+interface TokenCache {
+  token: string
+  expiresAt: number
+}
+
+export interface PiroCustomerInfo {
+  name?: string
+  email?: string
+  phone?: string
+}
+
+export interface PiroCreatePaymentRequest {
+  orderId: string
+  amount: number
+  description?: string
+  channel?: string
+  callbackUrl?: string
+  successUrl?: string
+  failureUrl?: string
+  expireMinutes?: number
+  customer?: PiroCustomerInfo
+}
+
+export interface PiroCreatePaymentResult {
+  paymentId: string
+  referenceId: string
+  status: string
+  checkoutUrl?: string
+  qrContent?: string
+  expiredAt?: string
+  raw: any
+}
+
+export interface PiroStatusResult {
+  paymentId: string
+  referenceId: string
+  status: string
+  grossAmount?: number
+  netAmount?: number
+  feeAmount?: number
+  checkoutUrl?: string
+  qrContent?: string
+  paidAt?: Date | null
+  expiredAt?: Date | null
+  settledAt?: Date | null
+  raw: any
+}
+
+const trimSlash = (input: string) => input.replace(/\/+$/, '')
+
+const parseNumber = (value: any): number | undefined => {
+  if (value == null) return undefined
+  const num = Number(value)
+  return Number.isFinite(num) ? num : undefined
+}
+
+const parseDate = (value: any): Date | null => {
+  if (!value) return null
+  if (value instanceof Date) return value
+  const str = typeof value === 'string' ? value.trim() : String(value)
+  if (!str) return null
+  const timestamp = Date.parse(str)
+  if (!Number.isNaN(timestamp)) return new Date(timestamp)
+  return null
+}
+
+const clean = <T extends Record<string, any>>(payload: T): T => {
+  const clone: Record<string, any> = {}
+  Object.entries(payload).forEach(([key, val]) => {
+    if (val === undefined || val === null) return
+    if (typeof val === 'object' && !Array.isArray(val)) {
+      const nested = clean(val as Record<string, any>)
+      if (Object.keys(nested).length === 0) return
+      clone[key] = nested
+    } else {
+      clone[key] = val
+    }
+  })
+  return clone as T
+}
+
+export class PiroClient {
+  private http: AxiosInstance
+  private tokenCache: TokenCache | null = null
+
+  constructor(private readonly config: PiroConfig) {
+    if (!config.baseUrl) throw new Error('Piro baseUrl is required')
+    if (!config.clientId) throw new Error('Piro clientId is required')
+    if (!config.clientSecret) throw new Error('Piro clientSecret is required')
+    if (!config.signatureKey) throw new Error('Piro signatureKey is required')
+    if (!config.merchantId) throw new Error('Piro merchantId is required')
+
+    this.http = axios.create({
+      baseURL: trimSlash(config.baseUrl),
+      headers: { 'Content-Type': 'application/json' },
+      timeout: 15000,
+    })
+  }
+
+  static computeSignature(payload: string, key: string): string {
+    return crypto.createHmac('sha256', key).update(payload, 'utf8').digest('hex')
+  }
+
+  verifySignature(rawBody: string, signature: string): boolean {
+    const expected = PiroClient.computeSignature(rawBody, this.config.signatureKey)
+    return expected === signature
+  }
+
+  clearCachedToken() {
+    this.tokenCache = null
+  }
+
+  private async ensureToken(): Promise<string> {
+    const now = Date.now()
+    if (this.tokenCache && this.tokenCache.expiresAt - 5000 > now) {
+      return this.tokenCache.token
+    }
+
+    const body = new URLSearchParams({
+      grant_type: 'client_credentials',
+      client_id: this.config.clientId,
+      client_secret: this.config.clientSecret,
+    })
+
+    logger.debug('[Piro] ▶ Request token')
+    const res = await this.http.post('/oauth/token', body.toString(), {
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    })
+    const token = String(res.data?.access_token ?? res.data?.token ?? '')
+    if (!token) throw new Error('Piro token response missing access_token')
+
+    const expiresIn = Number(res.data?.expires_in ?? 3600)
+    this.tokenCache = {
+      token,
+      expiresAt: now + expiresIn * 1000,
+    }
+    logger.debug('[Piro] ◀ Token acquired')
+    return token
+  }
+
+  private async authorizedHeaders(): Promise<Record<string, string>> {
+    const token = await this.ensureToken()
+    return {
+      Authorization: `Bearer ${token}`,
+    }
+  }
+
+  async createPayment(payload: PiroCreatePaymentRequest): Promise<PiroCreatePaymentResult> {
+    const headers = await this.authorizedHeaders()
+    const body = clean({
+      merchantId: this.config.merchantId,
+      storeId: this.config.storeId,
+      terminalId: this.config.terminalId,
+      channel: payload.channel ?? this.config.channel,
+      referenceId: payload.orderId,
+      orderId: payload.orderId,
+      amount: payload.amount,
+      description: payload.description,
+      callbackUrl: payload.callbackUrl ?? this.config.callbackUrl,
+      successUrl: payload.successUrl,
+      failureUrl: payload.failureUrl,
+      expireMinutes: payload.expireMinutes,
+      customer: payload.customer,
+    })
+
+    logger.info('[Piro] ▶ createPayment', { body })
+    const res = await this.http.post('/v1/payments', body, { headers })
+    logger.info('[Piro] ◀ createPayment', { data: res.data })
+    const data = res.data?.data ?? res.data
+    const payment = data?.payment ?? data
+
+    const paymentId = String(payment?.paymentId ?? payment?.payment_id ?? payment?.id ?? '')
+    const referenceId = String(payment?.referenceId ?? payment?.reference_id ?? payload.orderId)
+    const status = String(payment?.status ?? '')
+    const checkoutUrl =
+      payment?.checkoutUrl ?? payment?.checkout_url ?? payment?.redirectUrl ?? payment?.redirect_url
+    const qrContent =
+      payment?.qrContent ??
+      payment?.qr_content ??
+      payment?.qrString ??
+      payment?.qr_string ??
+      payment?.qrImageUrl ??
+      payment?.qr_image_url
+    const expiredAt = payment?.expiredAt ?? payment?.expired_at ?? payment?.expiration_time
+
+    return {
+      paymentId,
+      referenceId,
+      status,
+      checkoutUrl: checkoutUrl ? String(checkoutUrl) : undefined,
+      qrContent: qrContent ? String(qrContent) : undefined,
+      expiredAt: expiredAt ? String(expiredAt) : undefined,
+      raw: res.data,
+    }
+  }
+
+  async getPaymentStatus(reference: string): Promise<PiroStatusResult> {
+    const headers = await this.authorizedHeaders()
+    const url = `/v1/payments/${encodeURIComponent(reference)}`
+    logger.info('[Piro] ▶ getPaymentStatus', { reference })
+    const res = await this.http.get(url, { headers })
+    logger.info('[Piro] ◀ getPaymentStatus', { data: res.data })
+
+    const data = res.data?.data ?? res.data
+    const payment = data?.payment ?? data
+
+    const paymentId = String(payment?.paymentId ?? payment?.payment_id ?? payment?.id ?? reference)
+    const referenceId = String(payment?.referenceId ?? payment?.reference_id ?? payment?.orderId ?? reference)
+    const status = String(payment?.status ?? '')
+    const grossAmount =
+      parseNumber(payment?.grossAmount ?? payment?.gross_amount ?? payment?.amount) ?? undefined
+    const netAmount = parseNumber(payment?.netAmount ?? payment?.net_amount)
+    const feeAmount = parseNumber(payment?.feeAmount ?? payment?.fee_amount ?? payment?.fee)
+    const checkoutUrl =
+      payment?.checkoutUrl ?? payment?.checkout_url ?? payment?.redirectUrl ?? payment?.redirect_url
+    const qrContent =
+      payment?.qrContent ??
+      payment?.qr_content ??
+      payment?.qrString ??
+      payment?.qr_string ??
+      payment?.qrImageUrl ??
+      payment?.qr_image_url
+
+    const paidAt =
+      parseDate(payment?.paidAt ?? payment?.paid_at ?? payment?.paymentTime ?? payment?.payment_time) || null
+    const expiredAt =
+      parseDate(payment?.expiredAt ?? payment?.expired_at ?? payment?.expiration_time ?? payment?.expires_at) || null
+    const settledAt =
+      parseDate(payment?.settledAt ?? payment?.settled_at ?? payment?.settlement_time ?? payment?.settlementTime) || null
+
+    return {
+      paymentId,
+      referenceId,
+      status,
+      grossAmount,
+      netAmount,
+      feeAmount,
+      checkoutUrl: checkoutUrl ? String(checkoutUrl) : undefined,
+      qrContent: qrContent ? String(qrContent) : undefined,
+      paidAt,
+      expiredAt,
+      settledAt,
+      raw: res.data,
+    }
+  }
+}

--- a/src/service/piroFallback.ts
+++ b/src/service/piroFallback.ts
@@ -1,0 +1,111 @@
+import logger from '../logger'
+import { prisma } from '../core/prisma'
+import { PiroClient, PiroConfig } from './piroClient'
+import { processPiroUpdate } from './piroStatus'
+
+interface WatcherState {
+  attempts: number
+  timer?: NodeJS.Timeout
+}
+
+const BACKOFF_MINUTES = [3, 10, 30]
+const watchers = new Map<string, WatcherState>()
+
+export function cancelPiroFallback(orderId: string) {
+  const state = watchers.get(orderId)
+  if (state?.timer) clearTimeout(state.timer)
+  watchers.delete(orderId)
+}
+
+interface FallbackOptions {
+  paymentId?: string | null
+  referenceId?: string | null
+}
+
+export function schedulePiroFallback(
+  orderId: string,
+  cfg: PiroConfig,
+  opts: FallbackOptions = {}
+) {
+  if (!orderId) return
+  if (watchers.has(orderId)) return
+
+  const client = new PiroClient(cfg)
+  const state: WatcherState = { attempts: 0 }
+
+  const runCheck = async () => {
+    try {
+      const existingCb = await prisma.transaction_callback.findFirst({
+        where: { referenceId: orderId },
+      })
+      if (existingCb) {
+        cancelPiroFallback(orderId)
+        return
+      }
+
+      const order = await prisma.order.findUnique({
+        where: { id: orderId },
+        select: {
+          status: true,
+          pgRefId: true,
+          pgClientRef: true,
+        },
+      })
+
+      if (!order || order.status !== 'PENDING') {
+        cancelPiroFallback(orderId)
+        return
+      }
+
+      const inquiry =
+        opts.paymentId ??
+        order.pgRefId ??
+        opts.referenceId ??
+        order.pgClientRef ??
+        orderId
+
+      const resp = await client.getPaymentStatus(inquiry)
+      const statusUpper = (resp.status || '').toUpperCase()
+      if (
+        ['SUCCESS', 'PAID', 'DONE', 'COMPLETED', 'FAILED', 'CANCELLED', 'EXPIRED'].includes(
+          statusUpper
+        )
+      ) {
+        await processPiroUpdate({
+          orderId,
+          status: statusUpper,
+          paymentId: resp.paymentId,
+          referenceId: resp.referenceId,
+          grossAmount: resp.grossAmount,
+          netAmount: resp.netAmount,
+          feeAmount: resp.feeAmount,
+          checkoutUrl: resp.checkoutUrl,
+          qrContent: resp.qrContent,
+          paymentReceivedTime: resp.paidAt ?? undefined,
+          settlementTime: resp.settledAt ?? undefined,
+          expirationTime: resp.expiredAt ?? undefined,
+          raw: resp.raw,
+        })
+        cancelPiroFallback(orderId)
+        return
+      }
+    } catch (err: any) {
+      logger.error(`[PiroFallback] error for ${orderId}: ${err.message}`)
+    }
+
+    state.attempts += 1
+    if (state.attempts >= BACKOFF_MINUTES.length) {
+      cancelPiroFallback(orderId)
+      return
+    }
+
+    const delayMs = BACKOFF_MINUTES[state.attempts] * 60 * 1000
+    state.timer = setTimeout(runCheck, delayMs)
+    watchers.set(orderId, state)
+  }
+
+  const initialDelay = BACKOFF_MINUTES[0] * 60 * 1000
+  state.timer = setTimeout(runCheck, initialDelay)
+  watchers.set(orderId, state)
+  logger.info(`[PiroFallback] scheduled watcher for ${orderId}`)
+}

--- a/src/service/piroStatus.ts
+++ b/src/service/piroStatus.ts
@@ -1,0 +1,175 @@
+import crypto from 'crypto'
+import logger from '../logger'
+import { prisma } from '../core/prisma'
+import { computeSettlement } from './feeSettlement'
+import { isJakartaWeekend, wibTimestamp, wibTimestampString } from '../util/time'
+
+export interface PiroUpdateInput {
+  orderId: string
+  status: string
+  paymentId?: string | null
+  referenceId?: string | null
+  grossAmount?: number
+  netAmount?: number
+  feeAmount?: number
+  checkoutUrl?: string | null
+  qrContent?: string | null
+  paymentReceivedTime?: Date | string | null
+  settlementTime?: Date | string | null
+  expirationTime?: Date | string | null
+  raw?: any
+}
+
+const parseDate = (value: any): Date | undefined => {
+  if (!value) return undefined
+  if (value instanceof Date) return value
+  const str = typeof value === 'string' ? value.trim() : String(value)
+  if (!str) return undefined
+  const ts = Date.parse(str)
+  if (Number.isNaN(ts)) return undefined
+  return new Date(ts)
+}
+
+export async function processPiroUpdate(input: PiroUpdateInput): Promise<void> {
+  const orderId = input.orderId
+  if (!orderId) throw new Error('orderId is required for Piro update')
+
+  const order = await prisma.order.findUnique({
+    where: { id: orderId },
+    select: {
+      status: true,
+      userId: true,
+      partnerClientId: true,
+      amount: true,
+      qrPayload: true,
+    },
+  })
+
+  if (!order) throw new Error(`Order ${orderId} not found`)
+
+  if (order.status === 'SETTLED') {
+    logger.info(`[Piro] Order ${orderId} already settled; skipping status update`)
+    return
+  }
+
+  const statusUpper = (input.status || '').toUpperCase()
+  const isSuccess = ['SUCCESS', 'PAID', 'DONE', 'COMPLETED', 'SETTLED'].includes(statusUpper)
+  const isFailed = ['FAILED', 'CANCELLED', 'EXPIRED', 'VOID', 'ERROR'].includes(statusUpper)
+  const newStatus = statusUpper || order.status
+  const settlementStatus = isSuccess ? 'PENDING' : isFailed ? statusUpper : null
+
+  const paymentReceivedTime =
+    parseDate(input.paymentReceivedTime) ?? (isSuccess ? wibTimestamp() : undefined)
+  const settlementTime = parseDate(input.settlementTime) ?? null
+  const expirationTime = parseDate(input.expirationTime)
+
+  const partnerId = order.partnerClientId ?? order.userId
+  if (!partnerId) throw new Error(`Order ${orderId} missing partner client`)
+
+  const partner = await prisma.partnerClient.findUnique({
+    where: { id: partnerId },
+    select: {
+      feePercent: true,
+      feeFlat: true,
+      weekendFeePercent: true,
+      weekendFeeFlat: true,
+      callbackUrl: true,
+      callbackSecret: true,
+    },
+  })
+  if (!partner) throw new Error(`PartnerClient ${partnerId} not found`)
+
+  const grossAmount = input.grossAmount ?? order.amount
+  const weekend = isJakartaWeekend(paymentReceivedTime ?? wibTimestamp())
+  const percent = weekend ? partner.weekendFeePercent ?? 0 : partner.feePercent ?? 0
+  const flat = weekend ? partner.weekendFeeFlat ?? 0 : partner.feeFlat ?? 0
+  const { fee: feeLauncx, settlement } = computeSettlement(grossAmount, { percent, flat })
+
+  const updateData: any = {
+    status: isSuccess ? 'PAID' : newStatus,
+    settlementStatus,
+    fee3rdParty: input.feeAmount ?? undefined,
+    feeLauncx: isSuccess ? feeLauncx : null,
+    pendingAmount: isSuccess ? settlement : null,
+    settlementAmount: isSuccess ? null : input.netAmount ?? null,
+    paymentReceivedTime: paymentReceivedTime ?? undefined,
+    settlementTime,
+    trxExpirationTime: expirationTime ?? undefined,
+    pgRefId: input.paymentId ?? undefined,
+    pgClientRef: input.referenceId ?? undefined,
+    checkoutUrl: input.checkoutUrl ?? undefined,
+    qrPayload: input.qrContent ?? undefined,
+    updatedAt: wibTimestamp(),
+  }
+
+  if (input.raw) {
+    updateData.providerPayload = input.raw as any
+  }
+
+  await prisma.order.update({
+    where: { id: orderId },
+    data: updateData,
+  })
+
+  if (input.raw) {
+    const existingCb = await prisma.transaction_callback.findFirst({
+      where: { referenceId: orderId },
+    })
+
+    if (existingCb) {
+      await prisma.transaction_callback.update({
+        where: { id: existingCb.id },
+        data: {
+          requestBody: input.raw as any,
+          updatedAt: wibTimestamp(),
+          paymentReceivedTime: paymentReceivedTime ?? null,
+          settlementTime,
+          trxExpirationTime: expirationTime ?? null,
+        },
+      })
+    } else {
+      await prisma.transaction_callback.create({
+        data: {
+          referenceId: orderId,
+          requestBody: input.raw as any,
+          paymentReceivedTime: paymentReceivedTime ?? null,
+          settlementTime,
+          trxExpirationTime: expirationTime ?? null,
+        },
+      })
+    }
+  }
+
+  const updated = await prisma.order.findUnique({ where: { id: orderId } })
+
+  if (isSuccess && partner.callbackUrl && partner.callbackSecret && updated) {
+    const timestamp = wibTimestampString()
+    const nonce = crypto.randomUUID()
+    const payload = {
+      orderId,
+      status: 'PAID',
+      settlementStatus: settlementStatus ?? 'PENDING',
+      grossAmount: updated.amount,
+      feeLauncx: updated.feeLauncx,
+      netAmount: updated.pendingAmount,
+      qrPayload: updated.qrPayload ?? order.qrPayload ?? null,
+      timestamp,
+      nonce,
+    }
+
+    const signature = crypto
+      .createHmac('sha256', partner.callbackSecret)
+      .update(JSON.stringify(payload))
+      .digest('hex')
+
+    await prisma.callbackJob.create({
+      data: {
+        url: partner.callbackUrl,
+        payload,
+        signature,
+        partnerClientId: partnerId,
+      },
+    })
+    logger.info(`[Piro] Enqueued callback job for order ${orderId}`)
+  }
+}

--- a/test/helpers/testEnv.ts
+++ b/test/helpers/testEnv.ts
@@ -1,4 +1,8 @@
 process.env.JWT_SECRET = process.env.JWT_SECRET ?? 'test-secret'
+process.env.PIRO_BASE_URL = process.env.PIRO_BASE_URL ?? 'https://api.piro.test'
+process.env.PIRO_CLIENT_ID = process.env.PIRO_CLIENT_ID ?? 'test-client'
+process.env.PIRO_CLIENT_SECRET = process.env.PIRO_CLIENT_SECRET ?? 'test-secret'
+process.env.PIRO_SIGNATURE_KEY = process.env.PIRO_SIGNATURE_KEY ?? 'piro-signature'
 
 const globalForPrisma = globalThis as unknown as { prisma?: any }
 if (!globalForPrisma.prisma) {

--- a/test/piroCallback.test.ts
+++ b/test/piroCallback.test.ts
@@ -1,0 +1,133 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import './helpers/testEnv'
+
+import { piroTransactionCallback } from '../src/controller/payment'
+import { prisma } from '../src/core/prisma'
+import { PiroClient } from '../src/service/piroClient'
+
+const signatureKey = process.env.PIRO_SIGNATURE_KEY || 'piro-signature'
+
+test.afterEach(() => {
+  ;(prisma as any).order = undefined
+  ;(prisma as any).partnerClient = undefined
+  ;(prisma as any).transaction_callback = undefined
+  ;(prisma as any).callbackJob = undefined
+})
+
+test('piroTransactionCallback rejects invalid signature', { concurrency: false }, async () => {
+  const payload = { reference_id: 'order-1', status: 'PAID', amount: 1000 }
+  const raw = JSON.stringify(payload)
+
+  let result: any = null
+  const req: any = {
+    rawBody: Buffer.from(raw, 'utf8'),
+    header: (name: string) => {
+      if (name.toLowerCase().includes('signature')) return 'invalid'
+      return undefined
+    },
+  }
+  const res: any = {
+    status(code: number) {
+      return {
+        json(body: any) {
+          result = { code, body }
+        },
+      }
+    },
+  }
+
+  await piroTransactionCallback(req, res)
+  assert.ok(result, 'response should be captured')
+  assert.equal(result.code, 400)
+  assert.match(result.body.error, /signature/i)
+})
+
+test('piroTransactionCallback processes valid payload', { concurrency: false }, async () => {
+  const payload = {
+    reference_id: 'order-123',
+    payment_id: 'pi-1',
+    status: 'PAID',
+    amount: 12500,
+  }
+  const raw = JSON.stringify(payload)
+  const signature = PiroClient.computeSignature(raw, signatureKey)
+
+  let orderFindCount = 0
+  let capturedUpdate: any = null
+  let callbackJobPayload: any = null
+
+  ;(prisma as any).order = {
+    findUnique: async () => {
+      orderFindCount += 1
+      if (orderFindCount >= 2) {
+        return {
+          amount: 12500,
+          feeLauncx: 0,
+          pendingAmount: 12500,
+          qrPayload: null,
+        }
+      }
+      return {
+        status: 'PENDING',
+        userId: 'partner-1',
+        partnerClientId: 'partner-1',
+        amount: 12500,
+        qrPayload: null,
+      }
+    },
+    update: async (args: any) => {
+      capturedUpdate = args
+      return {}
+    },
+  }
+
+  ;(prisma as any).partnerClient = {
+    findUnique: async () => ({
+      feePercent: 0,
+      feeFlat: 0,
+      weekendFeePercent: 0,
+      weekendFeeFlat: 0,
+      callbackUrl: 'https://example.com/callback',
+      callbackSecret: 'cb-secret',
+    }),
+  }
+
+  ;(prisma as any).transaction_callback = {
+    findFirst: async () => null,
+    create: async () => {},
+  }
+
+  ;(prisma as any).callbackJob = {
+    create: async (args: any) => {
+      callbackJobPayload = args
+    },
+  }
+
+  let result: any = null
+  const req: any = {
+    rawBody: Buffer.from(raw, 'utf8'),
+    header(name: string) {
+      if (name.toLowerCase().includes('signature')) return signature
+      return undefined
+    },
+  }
+  const res: any = {
+    status(code: number) {
+      return {
+        json(body: any) {
+          result = { code, body }
+        },
+      }
+    },
+  }
+
+  await piroTransactionCallback(req, res)
+
+  assert.equal(result.code, 200)
+  assert.ok(capturedUpdate, 'order update should be called')
+  assert.equal(capturedUpdate.data.status, 'PAID')
+  assert.ok(callbackJobPayload, 'callback job should be enqueued')
+  assert.equal(callbackJobPayload.data.url, 'https://example.com/callback')
+})


### PR DESCRIPTION
## Summary
- add Piro client, fallback watcher, and status processing utilities
- expose Piro credentials in configuration and provider selection
- update payment flows, controller routes, and tests to support Piro transactions and callbacks

## Testing
- node --test -r ts-node/register test/piroCallback.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d77c3377348328b52957636fe4cfc0