### PR TITLE
Add Piro withdrawal integration with validation and callback handling

### DIFF
--- a/frontend/src/utils/piroBankMap.test.ts
+++ b/frontend/src/utils/piroBankMap.test.ts
@@ -1,0 +1,17 @@
+import { test } from 'node:test'
+import assert from 'node:assert'
+import { resolvePiroBankMeta } from './piroBankMap'
+
+test('resolvePiroBankMeta maps known aliases', () => {
+  const meta = resolvePiroBankMeta('Bank Mandiri', '999')
+  assert.equal(meta.bankCode, '008')
+  assert.equal(meta.branchCode, '0080010')
+  assert.equal(meta.bankIdentifier, 'BMRIIDJA')
+})
+
+test('resolvePiroBankMeta falls back to provided code', () => {
+  const meta = resolvePiroBankMeta('Bank Tidak Ada', '123')
+  assert.equal(meta.bankCode, '123')
+  assert.equal(meta.branchCode, '1230001')
+  assert.equal(meta.bankIdentifier, '123')
+})

--- a/frontend/src/utils/piroBankMap.ts
+++ b/frontend/src/utils/piroBankMap.ts
@@ -1,0 +1,76 @@
+export interface PiroBankMeta {
+  bankCode: string
+  branchCode: string
+  bankIdentifier: string
+}
+
+interface PiroBankEntry extends PiroBankMeta {
+  aliases: string[]
+}
+
+const BANK_ENTRIES: PiroBankEntry[] = [
+  {
+    aliases: ['bank central asia', 'bca'],
+    bankCode: '014',
+    branchCode: '0140010',
+    bankIdentifier: 'CENAIDJAXXX',
+  },
+  {
+    aliases: ['bank mandiri', 'mandiri'],
+    bankCode: '008',
+    branchCode: '0080010',
+    bankIdentifier: 'BMRIIDJA',
+  },
+  {
+    aliases: ['bank rakyat indonesia', 'bri'],
+    bankCode: '002',
+    branchCode: '0020001',
+    bankIdentifier: 'BRINIDJA',
+  },
+  {
+    aliases: ['bank negara indonesia', 'bni'],
+    bankCode: '009',
+    branchCode: '0090001',
+    bankIdentifier: 'BNINIDJAXXX',
+  },
+  {
+    aliases: ['permata', 'bank permata'],
+    bankCode: '013',
+    branchCode: '0130001',
+    bankIdentifier: 'BBBAIDJA',
+  },
+  {
+    aliases: ['cimb niaga', 'bank cimb'],
+    bankCode: '022',
+    branchCode: '0220001',
+    bankIdentifier: 'BNIAIDJA',
+  },
+]
+
+const LOOKUP = new Map<string, PiroBankMeta>()
+BANK_ENTRIES.forEach(entry => {
+  entry.aliases.forEach(alias => {
+    LOOKUP.set(alias.trim().toLowerCase(), {
+      bankCode: entry.bankCode,
+      branchCode: entry.branchCode,
+      bankIdentifier: entry.bankIdentifier,
+    })
+  })
+})
+
+export function resolvePiroBankMeta(bankName?: string, fallbackCode = ''): PiroBankMeta {
+  if (bankName) {
+    const normalized = bankName.trim().toLowerCase()
+    const found = LOOKUP.get(normalized)
+    if (found) {
+      return found
+    }
+  }
+
+  const safeCode = fallbackCode || '000'
+  return {
+    bankCode: safeCode,
+    branchCode: `${safeCode}0001`,
+    bankIdentifier: safeCode,
+  }
+}

--- a/src/app.ts
+++ b/src/app.ts
@@ -24,7 +24,7 @@ import usersRoutes from './route/users.routes';
 import settingsRoutes   from './route/settings.routes';
 import { loadWeekendOverrideDates } from './util/time'
 
-import { withdrawalCallback, ing1WithdrawalCallback } from './controller/withdrawals.controller'
+import { withdrawalCallback, ing1WithdrawalCallback, piroWithdrawalCallback } from './controller/withdrawals.controller'
 import pivotCallbackRouter from './route/payment.callback.routes';
 
 import webRoutes from './route/web.routes';
@@ -75,6 +75,7 @@ const rateLimitExemptPaths = new Set([
   '/api/v1/transaction/callback/ing1',
   '/api/v1/transaction/callback/oy',
   '/api/v1/withdrawals/callback',
+  '/api/v1/withdrawals/callback/piro',
   '/api/v1/withdrawals/callback/ing1',
 ]);
 
@@ -117,6 +118,18 @@ app.post(
     },
   }),
   withdrawalCallback           // ⛔ TANPA express.json()
+);
+
+app.post(
+  '/api/v1/withdrawals/callback/piro',
+  express.raw({
+    type: '*/*',
+    limit: '2mb',
+    verify: (req, _res, buf) => {
+      (req as any).rawBody = buf.toString('utf8')
+    },
+  }),
+  piroWithdrawalCallback,
 );
 
 app.get('/api/v1/withdrawals/callback/ing1', ing1WithdrawalCallback);

--- a/src/service/provider.ts
+++ b/src/service/provider.ts
@@ -131,6 +131,9 @@ export async function getActiveProviders(
   // 2) filter schedule aktif
   const activeSubs = subs.filter((s) => {
     const sch = (s.schedule as any) || {};
+    if (sch.weekday == null && sch.weekend == null) {
+      return true;
+    }
     return !!sch[schedulePath];
   });
 

--- a/test/piroWithdrawalCallback.test.ts
+++ b/test/piroWithdrawalCallback.test.ts
@@ -1,0 +1,91 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+process.env.JWT_SECRET = process.env.JWT_SECRET ?? 'test'
+
+import { piroWithdrawalCallback } from '../src/controller/withdrawals.controller'
+import { prisma } from '../src/core/prisma'
+import { PiroClient } from '../src/service/piroClient'
+import { config } from '../src/config'
+
+config.api.piro.signatureKey = 'piro-signature'
+
+test('piroWithdrawalCallback rejects invalid signature', async () => {
+  const req: any = {
+    rawBody: JSON.stringify({ referenceId: 'wd-1', status: 'SUCCESS' }),
+    header: (name: string) => (name.toLowerCase() === 'x-piro-signature' ? 'bad' : ''),
+  }
+
+  const captured: any[] = []
+  const res: any = {
+    status(code: number) {
+      captured.push(code)
+      return {
+        json(payload: any) {
+          captured.push(payload.error)
+        },
+      }
+    },
+    json() {
+      captured.push('unexpected')
+    },
+  }
+
+  await piroWithdrawalCallback(req, res)
+  assert.equal(captured[0], 400)
+  assert.equal(captured[1], 'Invalid signature')
+})
+
+test('piroWithdrawalCallback updates pending withdrawal', async () => {
+  let statusStore = 'PENDING'
+  let pgId: string | undefined
+  let feeStore: number | undefined
+  let balanceChange = 0
+
+  ;(prisma as any).withdrawRequest = {
+    findUnique: async () => ({ status: statusStore, partnerClientId: 'pc-1', amount: 250000 }),
+    updateMany: async ({ data }: any) => {
+      statusStore = data.status
+      pgId = data.paymentGatewayId
+      feeStore = data.pgFee
+      return { count: 1 }
+    },
+  }
+
+  ;(prisma as any).partnerClient = {
+    update: async ({ data }: any) => {
+      if (data.balance?.increment) balanceChange += data.balance.increment
+      if (data.balance?.decrement) balanceChange -= data.balance.decrement
+    },
+  }
+
+  const body = {
+    referenceId: 'wd-2',
+    status: 'SUCCESS',
+    disbursementId: 'piro-123',
+    feeAmount: 1500,
+    accountName: 'John Doe',
+    bankName: 'Bank Mandiri',
+  }
+
+  const signature = PiroClient.computeSignature(JSON.stringify(body), config.api.piro.signatureKey)
+  const req: any = {
+    rawBody: JSON.stringify(body),
+    header: (name: string) => (name.toLowerCase() === 'x-piro-signature' ? signature : ''),
+  }
+
+  const res: any = {
+    json(payload: any) {
+      assert.deepEqual(payload, { ok: true })
+    },
+    status(code: number) {
+      throw new Error(`unexpected status ${code}`)
+    },
+  }
+
+  await piroWithdrawalCallback(req, res)
+  assert.equal(statusStore, 'COMPLETED')
+  assert.equal(pgId, 'piro-123')
+  assert.equal(feeStore, 1500)
+  assert.equal(balanceChange, 0)
+})


### PR DESCRIPTION
## Summary
- implement the Piro service client and wire provider selection into withdrawal validation flows
- expose the Piro callback endpoint, provider discovery, and extend the client withdrawal form/mapping
- add backend and frontend unit tests that cover the new Piro withdrawal paths

## Testing
- JWT_SECRET=test node --test -r ts-node/register test/withdrawalCallback.test.ts test/piroWithdrawalCallback.test.ts
- node --test -r ts-node/register frontend/src/utils/piroBankMap.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d7802706788328b33e9831aa3ccfad