### PR TITLE
Add Piro credential support for sub merchant management

### DIFF
--- a/src/controller/admin/subMerchant.controller.ts
+++ b/src/controller/admin/subMerchant.controller.ts
@@ -11,7 +11,7 @@ const scheduleSchema = z.object({
 });
 const nameSchema = z.string().min(1)
 
-const providerSchema = z.enum(['hilogate', 'oy', 'netzme', '2c2p', 'gidi', 'ing1']);
+const providerSchema = z.enum(['hilogate', 'oy', 'netzme', '2c2p', 'gidi', 'ing1', 'piro']);
 
 // GET /admin/merchant/:merchantId/pg
 export async function listSubMerchants(req: Request, res: Response) {

--- a/test/credentials.piro.test.ts
+++ b/test/credentials.piro.test.ts
@@ -1,0 +1,34 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { parseRawCredential, normalizeCredentials } from '../src/util/credentials'
+
+test('normalizeCredentials maps Piro aliases and trims values', () => {
+  const raw = parseRawCredential('piro', {
+    merchant_id: '  MID-123  ',
+    storeID: ' Store-1 ',
+    terminal_id: ' TERM-9 ',
+    channelCode: ' CHANNEL ',
+    callbackURL: 'https://callback.test',
+  })
+
+  const normalized = normalizeCredentials('piro', raw)
+
+  assert.deepEqual(normalized, {
+    provider: 'piro',
+    merchantId: 'MID-123',
+    storeId: 'Store-1',
+    terminalId: 'TERM-9',
+    channel: 'CHANNEL',
+    callbackUrl: 'https://callback.test',
+  })
+})
+
+test('normalizeCredentials rejects incomplete Piro credentials', () => {
+  const raw = parseRawCredential('piro', { storeId: 'store-only' })
+
+  assert.throws(() => normalizeCredentials('piro', raw), (error: any) => {
+    assert.equal(error?.name, 'ZodError')
+    return true
+  })
+})


### PR DESCRIPTION
## Summary
- allow the admin sub-merchant controller to accept the Piro provider
- add Piro credential parsing/normalization with alias support
- cover successful and invalid Piro credential flows with unit tests

## Testing
- node --test -r ts-node/register test/credentials.piro.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d7981a34c08328a9598b14c18961ca