### PR TITLE
feat: switch Piro signatures to md5

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -140,6 +140,9 @@ oy: {
       clientSecret: process.env.PIRO_CLIENT_SECRET || '',
       signatureKey: process.env.PIRO_SIGNATURE_KEY || '',
       callbackUrl: process.env.PIRO_CALLBACK_URL || '',
+      deviceId: process.env.PIRO_DEVICE_ID || 'web',
+      latitude: process.env.PIRO_LATITUDE || '',
+      longitude: process.env.PIRO_LONGITUDE || '',
     },
   },
   aws: {

--- a/src/controller/payment.ts
+++ b/src/controller/payment.ts
@@ -851,7 +851,7 @@ export const piroTransactionCallback = async (req: Request, res: Response) => {
     const signatureKey = config.api.piro.signatureKey
     if (!signatureKey) throw new Error('Missing Piro signature key configuration')
 
-    const expected = PiroClient.computeSignature(rawBody, signatureKey)
+    const expected = PiroClient.callbackSignature(rawBody, signatureKey)
     if (signature !== expected) throw new Error('Invalid Piro signature')
 
     const payload = JSON.parse(rawBody) as Record<string, any>

--- a/src/controller/withdrawals.controller.ts
+++ b/src/controller/withdrawals.controller.ts
@@ -642,7 +642,7 @@ export const piroWithdrawalCallback = async (req: Request, res: Response) => {
       return res.status(400).json({ error: 'Missing signature' })
     }
 
-    const expected = PiroClient.computeSignature(raw, config.api.piro.signatureKey)
+    const expected = PiroClient.callbackSignature(raw, config.api.piro.signatureKey)
     if (expected !== signature) {
       return res.status(400).json({ error: 'Invalid signature' })
     }

--- a/src/service/provider.ts
+++ b/src/service/provider.ts
@@ -217,7 +217,8 @@ export async function getActiveProviders(
         throw new Error(`Invalid Piro credentials for sub_merchant ${s.id}`);
       }
 
-      const { baseUrl, clientId, clientSecret, signatureKey, callbackUrl } = config.api.piro;
+      const { baseUrl, clientId, clientSecret, signatureKey, callbackUrl, deviceId, latitude, longitude } =
+        config.api.piro;
       if (!baseUrl || !clientId || !signatureKey) {
         throw new Error('Piro environment credentials are not configured');
       }
@@ -243,6 +244,9 @@ export async function getActiveProviders(
           raw?.returnUrl ??
           raw?.return_url ??
           callbackUrl ?? config.api.callbackUrl,
+        deviceId: raw?.deviceId ?? raw?.device_id ?? deviceId,
+        latitude: String(raw?.latitude ?? raw?.lat ?? latitude ?? ''),
+        longitude: String(raw?.longitude ?? raw?.long ?? longitude ?? ''),
       };
 
       return {

--- a/test/piroCallback.test.ts
+++ b/test/piroCallback.test.ts
@@ -3,9 +3,10 @@ import assert from 'node:assert/strict'
 
 import './helpers/testEnv'
 
+import crypto from 'crypto'
+
 import { piroTransactionCallback } from '../src/controller/payment'
 import { prisma } from '../src/core/prisma'
-import { PiroClient } from '../src/service/piroClient'
 
 const signatureKey = process.env.PIRO_SIGNATURE_KEY || 'piro-signature'
 
@@ -52,7 +53,7 @@ test('piroTransactionCallback processes valid payload', { concurrency: false }, 
     amount: 12500,
   }
   const raw = JSON.stringify(payload)
-  const signature = PiroClient.computeSignature(raw, signatureKey)
+  const signature = crypto.createHash('md5').update(raw + signatureKey, 'utf8').digest('hex')
 
   let orderFindCount = 0
   let capturedUpdate: any = null

--- a/test/piroWithdrawalCallback.test.ts
+++ b/test/piroWithdrawalCallback.test.ts
@@ -5,9 +5,10 @@ process.env.JWT_SECRET = process.env.JWT_SECRET ?? 'test'
 
 import './helpers/testEnv'
 
+import crypto from 'crypto'
+
 import { piroWithdrawalCallback } from '../src/controller/withdrawals.controller'
 import { prisma } from '../src/core/prisma'
-import { PiroClient } from '../src/service/piroClient'
 import { config } from '../src/config'
 
 config.api.piro.signatureKey = 'piro-signature'
@@ -70,9 +71,10 @@ test('piroWithdrawalCallback updates pending withdrawal', async () => {
     bankName: 'Bank Mandiri',
   }
 
-  const signature = PiroClient.computeSignature(JSON.stringify(body), config.api.piro.signatureKey)
+  const raw = JSON.stringify(body)
+  const signature = crypto.createHash('md5').update(raw + config.api.piro.signatureKey, 'utf8').digest('hex')
   const req: any = {
-    rawBody: JSON.stringify(body),
+    rawBody: raw,
     header: (name: string) => (name.toLowerCase() === 'x-piro-signature' ? signature : ''),
   }
 


### PR DESCRIPTION
## Summary
- add MD5 signature helpers to `PiroClient` and include device/location metadata when building headers
- compute per-endpoint signatures for Piro payments, disbursements, and callbacks using the documented formulas
- update callback verification and unit tests to cover the new MD5 signatures end-to-end

## Testing
- TS_NODE_TRANSPILE_ONLY=1 node --test -r ts-node/register test/piroClient.test.ts test/piroCallback.test.ts test/piroWithdrawalCallback.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d79dd3e79083288f1da2d187b3b7be