### PR TITLE
Add Genesis QRIS client integration

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -144,6 +144,12 @@ oy: {
       latitude: process.env.PIRO_LATITUDE || '',
       longitude: process.env.PIRO_LONGITUDE || '',
     },
+    genesis: {
+      enabled: /^true$/i.test(process.env.GENESIS_ENABLED || ''),
+      baseUrl: process.env.GENESIS_BASE_URL || '',
+      secret: process.env.GENESIS_SECRET || 'abc',
+      callbackUrl: process.env.GENESIS_CALLBACK_URL || '',
+    },
   },
   aws: {
     region: process.env.AWS_REGION || 'ap-southeast-1',

--- a/src/service/genesisClient.ts
+++ b/src/service/genesisClient.ts
@@ -1,0 +1,325 @@
+import axios, { AxiosInstance } from 'axios'
+import crypto from 'crypto'
+import logger from '../logger'
+
+export interface GenesisClientConfig {
+  baseUrl: string
+  secret: string
+  callbackUrl?: string
+  defaultClientId?: string
+  defaultClientSecret?: string
+}
+
+export interface GenesisRegisterPayload {
+  id: string
+  payload: {
+    UID: string
+    email: string
+    mobile: string
+    username: string
+    password: string
+    callbackClient: string
+    banksAccount: {
+      bankName: string
+      accountNumber: string
+      accountName: string
+      bankBICode?: string
+    }
+  }
+  dto: string
+  collection: string
+  idAdmin: string
+  timestamp: number
+}
+
+export interface GenesisRegisterResult {
+  UID: string
+  username: string
+  password: string
+  callbackClient: string
+  clientId: string
+  clientSecret: string
+  raw: any
+}
+
+export interface GenesisGenerateQrisRequest {
+  orderId: string
+  amount: number | string
+  clientId?: string
+  clientSecret?: string
+}
+
+export interface GenesisGenerateQrisResult {
+  orderId: string
+  tx: string
+  clientId: string
+  qrisData: string
+  raw: any
+}
+
+export interface GenesisQueryRequest {
+  orderId: string
+  clientId?: string
+  clientSecret?: string
+}
+
+export interface GenesisQueryResult {
+  orderId: string
+  tx?: string
+  clientId?: string
+  status: string
+  responseCode?: string
+  responseMessage?: string
+  paidTime?: string
+  amount?: number
+  raw: any
+}
+
+export interface GenesisCallbackPayload {
+  TX?: string
+  amountSend?: number
+  clientId?: string
+  orderId?: string
+  paymentStatus?: string
+  attachment?: {
+    amount?: {
+      value?: string
+    }
+    paidTime?: string
+  }
+  [key: string]: any
+}
+
+const trimSlash = (input: string) => input.replace(/\/+$/, '')
+
+const toAmountString = (value: number | string): string => {
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) return String(value)
+    return value.toFixed(2)
+  }
+  const parsed = Number(value)
+  if (Number.isFinite(parsed)) return parsed.toFixed(2)
+  const str = String(value)
+  if (str.includes('.')) {
+    const [int, frac] = str.split('.')
+    return `${int}.${(frac ?? '').padEnd(2, '0').slice(0, 2)}`
+  }
+  if (!str) return '0.00'
+  return `${str}.00`
+}
+
+const md5 = (parts: Array<string | number | undefined | null>): string => {
+  const normalized = parts
+    .flatMap((part) => (Array.isArray(part) ? part : [part]))
+    .filter((part) => part !== undefined && part !== null)
+    .map((part) => {
+      if (typeof part === 'string') return part
+      if (typeof part === 'number') return Number.isFinite(part) ? String(part) : ''
+      if (part instanceof Date) return part.toISOString()
+      return String(part)
+    })
+  return crypto.createHash('md5').update(normalized.join(''), 'utf8').digest('hex')
+}
+
+const extractAmount = (payload: GenesisCallbackPayload): string | null => {
+  if (payload.attachment?.amount?.value) {
+    return toAmountString(payload.attachment.amount.value)
+  }
+  if (payload.amountSend != null) {
+    return toAmountString(payload.amountSend)
+  }
+  const direct = (payload as any).amount
+  if (direct != null) {
+    return toAmountString(direct)
+  }
+  return null
+}
+
+export class GenesisClient {
+  private http: AxiosInstance
+
+  constructor(private readonly config: GenesisClientConfig) {
+    if (!config.baseUrl) throw new Error('Genesis baseUrl is required')
+    if (!config.secret) throw new Error('Genesis secret is required')
+    this.http = axios.create({
+      baseURL: trimSlash(config.baseUrl),
+      headers: { 'Content-Type': 'application/json' },
+      timeout: 15000,
+      proxy: false,
+    })
+  }
+
+  static registrationSignature(input: {
+    email: string
+    username: string
+    password: string
+    callbackClient: string
+    secret: string
+  }): string {
+    return md5([input.email, input.username, input.password, input.callbackClient, input.secret])
+  }
+
+  static qrisSignature(input: {
+    clientId: string
+    value: number | string
+    orderId: string
+    clientSecret: string
+  }): string {
+    return md5([input.clientId, toAmountString(input.value), input.orderId, input.clientSecret])
+  }
+
+  static querySignature(input: { clientId: string; orderId: string; clientSecret: string }): string {
+    return md5([input.clientId, input.orderId, input.clientSecret])
+  }
+
+  static callbackSignature(payload: GenesisCallbackPayload, clientSecret: string, fallbackClientId?: string): string {
+    const clientId = payload.clientId ?? (payload as any).client_id ?? fallbackClientId ?? ''
+    const orderId = payload.orderId ?? (payload as any).order_id ?? ''
+    const amount = extractAmount(payload) ?? '0.00'
+    return GenesisClient.qrisSignature({ clientId, value: amount, orderId, clientSecret })
+  }
+
+  async registerMerchant(request: GenesisRegisterPayload): Promise<GenesisRegisterResult> {
+    const callbackClient = request.payload.callbackClient || this.config.callbackUrl || ''
+    const secret = this.config.secret
+    const signature = GenesisClient.registrationSignature({
+      email: request.payload.email,
+      username: request.payload.username,
+      password: request.payload.password,
+      callbackClient,
+      secret,
+    })
+
+    const body = {
+      ...request,
+      payload: {
+        ...request.payload,
+        callbackClient,
+      },
+    }
+
+    logger.info('[Genesis] ▶ registerMerchant', { body })
+    const res = await this.http.post('/user2gen/v1/user-register-create', body, {
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+        'x-signature': signature,
+      },
+    })
+    logger.info('[Genesis] ◀ registerMerchant', { data: res.data })
+
+    const data = res.data?.data ?? res.data
+    return {
+      UID: data?.UID ?? data?.uid ?? '',
+      username: data?.username ?? '',
+      password: data?.password ?? '',
+      callbackClient: data?.callbackClient ?? callbackClient,
+      clientId: data?.clientId ?? data?.client_id ?? '',
+      clientSecret: data?.clientSecret ?? data?.client_secret ?? '',
+      raw: res.data,
+    }
+  }
+
+  async generateQris(payload: GenesisGenerateQrisRequest): Promise<GenesisGenerateQrisResult> {
+    const clientId = payload.clientId ?? this.config.defaultClientId
+    const clientSecret = payload.clientSecret ?? this.config.defaultClientSecret ?? this.config.secret
+
+    if (!clientId) throw new Error('Genesis clientId is required for QR generation')
+    if (!clientSecret) throw new Error('Genesis clientSecret is required for QR generation')
+
+    const amount = toAmountString(payload.amount)
+    const signature = GenesisClient.qrisSignature({
+      clientId,
+      value: amount,
+      orderId: payload.orderId,
+      clientSecret,
+    })
+
+    const headers = {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+      'client_id': clientId,
+      'x-signature': signature,
+    }
+
+    const body = {
+      value: amount,
+      orderId: payload.orderId,
+    }
+
+    logger.info('[Genesis] ▶ generateQris', { headers, body })
+    const res = await this.http.post('/qrissnap2gen/v1/qr-mpm-generate-order', body, { headers })
+    logger.info('[Genesis] ◀ generateQris', { data: res.data })
+
+    const data = res.data ?? {}
+    return {
+      orderId: data.orderId ?? payload.orderId,
+      tx: data.TX ?? data.tx ?? '',
+      clientId: data.clientId ?? clientId,
+      qrisData: data.qrisData ?? data.qris ?? '',
+      raw: res.data,
+    }
+  }
+
+  async queryQris(payload: GenesisQueryRequest): Promise<GenesisQueryResult> {
+    const clientId = payload.clientId ?? this.config.defaultClientId
+    const clientSecret = payload.clientSecret ?? this.config.defaultClientSecret ?? this.config.secret
+    if (!clientId) throw new Error('Genesis clientId is required for QR inquiry')
+    if (!clientSecret) throw new Error('Genesis clientSecret is required for QR inquiry')
+
+    const signature = GenesisClient.querySignature({
+      clientId,
+      orderId: payload.orderId,
+      clientSecret,
+    })
+
+    const headers = {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+      'client_id': clientId,
+      'x-signature': signature,
+    }
+
+    logger.info('[Genesis] ▶ queryQris', { payload })
+    const res = await this.http.post('/qrissnap2gen/v1/qr-mpm-query', { orderId: payload.orderId }, { headers })
+    logger.info('[Genesis] ◀ queryQris', { data: res.data })
+
+    const data = res.data ?? {}
+    const status = data.data?.transactionStatusDesc ?? data.data?.status ?? data.paymentStatus ?? ''
+    const amountValue = data.data?.amount?.value ?? data.amount?.value ?? null
+    const paidTime = data.data?.paidTime ?? data.attachment?.paidTime ?? null
+
+    return {
+      orderId: data.orderId ?? payload.orderId,
+      tx: data.TX ?? data.tx,
+      clientId: data.clientId ?? clientId,
+      status: status || '',
+      responseCode: data.data?.responseCode ?? data.responseCode,
+      responseMessage: data.data?.responseMessage ?? data.responseMessage,
+      paidTime: paidTime ?? undefined,
+      amount: amountValue != null ? Number(amountValue) : undefined,
+      raw: res.data,
+    }
+  }
+
+  validateCallbackSignature(rawBody: string, signature: string | null | undefined, clientSecret?: string) {
+    if (!signature) throw new Error('Missing Genesis signature header')
+    let parsed: GenesisCallbackPayload
+    try {
+      parsed = JSON.parse(rawBody || '{}')
+    } catch (err) {
+      throw new Error('Invalid JSON payload for Genesis callback')
+    }
+
+    const secret = clientSecret ?? this.config.defaultClientSecret ?? this.config.secret
+    if (!secret) throw new Error('Genesis clientSecret is required for callback validation')
+    const expected = GenesisClient.callbackSignature(parsed, secret, this.config.defaultClientId)
+    if (signature !== expected) {
+      throw new Error('Invalid Genesis signature')
+    }
+
+    return parsed
+  }
+}
+
+export const formatGenesisAmount = toAmountString

--- a/src/service/genesisFallback.ts
+++ b/src/service/genesisFallback.ts
@@ -1,0 +1,104 @@
+import logger from '../logger'
+import { prisma } from '../core/prisma'
+import { GenesisClient, GenesisClientConfig } from './genesisClient'
+import { processPiroUpdate } from './piroStatus'
+
+interface WatcherState {
+  attempts: number
+  timer?: NodeJS.Timeout
+}
+
+interface GenesisFallbackOptions {
+  clientId: string
+  clientSecret: string
+  referenceId?: string
+  paymentId?: string | null
+}
+
+const BACKOFF_MINUTES = [3, 10, 30]
+const watchers = new Map<string, WatcherState>()
+
+export function cancelGenesisFallback(orderId: string) {
+  const state = watchers.get(orderId)
+  if (state?.timer) clearTimeout(state.timer)
+  watchers.delete(orderId)
+}
+
+export function scheduleGenesisFallback(
+  orderId: string,
+  cfg: GenesisClientConfig,
+  opts: GenesisFallbackOptions,
+) {
+  if (!orderId) return
+  if (watchers.has(orderId)) return
+
+  const client = new GenesisClient(cfg)
+  const state: WatcherState = { attempts: 0 }
+
+  const runCheck = async () => {
+    try {
+      const existingCb = await prisma.transaction_callback.findFirst({
+        where: { referenceId: orderId },
+      })
+      if (existingCb) {
+        cancelGenesisFallback(orderId)
+        return
+      }
+
+      const order = await prisma.order.findUnique({
+        where: { id: orderId },
+        select: {
+          status: true,
+          pgRefId: true,
+          pgClientRef: true,
+        },
+      })
+
+      if (!order || order.status !== 'PENDING') {
+        cancelGenesisFallback(orderId)
+        return
+      }
+
+      const reference = opts.referenceId ?? order.pgClientRef ?? orderId
+      const resp = await client.queryQris({
+        orderId: reference,
+        clientId: opts.clientId || cfg.defaultClientId,
+        clientSecret: opts.clientSecret || cfg.defaultClientSecret || cfg.secret,
+      })
+
+      const statusUpper = (resp.status || '').toUpperCase()
+      if (
+        ['SUCCESS', 'PAID', 'DONE', 'COMPLETED', 'FAILED', 'CANCELLED', 'EXPIRED'].includes(statusUpper)
+      ) {
+        await processPiroUpdate({
+          orderId,
+          status: statusUpper,
+          paymentId: resp.tx ?? opts.paymentId ?? order.pgRefId ?? null,
+          referenceId: resp.orderId ?? reference,
+          grossAmount: resp.amount,
+          paymentReceivedTime: resp.paidTime ?? undefined,
+          raw: resp.raw,
+        })
+        cancelGenesisFallback(orderId)
+        return
+      }
+    } catch (err: any) {
+      logger.error(`[GenesisFallback] error for ${orderId}: ${err.message}`)
+    }
+
+    state.attempts += 1
+    if (state.attempts >= BACKOFF_MINUTES.length) {
+      cancelGenesisFallback(orderId)
+      return
+    }
+
+    const delayMs = BACKOFF_MINUTES[state.attempts] * 60 * 1000
+    state.timer = setTimeout(runCheck, delayMs)
+    watchers.set(orderId, state)
+  }
+
+  const initialDelay = BACKOFF_MINUTES[0] * 60 * 1000
+  state.timer = setTimeout(runCheck, initialDelay)
+  watchers.set(orderId, state)
+  logger.info(`[GenesisFallback] scheduled watcher for ${orderId}`)
+}

--- a/test/genesisClient.test.ts
+++ b/test/genesisClient.test.ts
@@ -1,0 +1,117 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import nock from 'nock'
+
+import {
+  GenesisClient,
+  GenesisClientConfig,
+} from '../src/service/genesisClient'
+
+delete process.env.http_proxy
+delete process.env.HTTP_PROXY
+delete process.env.https_proxy
+delete process.env.HTTPS_PROXY
+
+const baseConfig: GenesisClientConfig = {
+  baseUrl: 'https://genesis.test',
+  secret: 'abc',
+  callbackUrl: 'https://merchant.test/callback',
+  defaultClientId: 'client-123',
+  defaultClientSecret: 'secret-456',
+}
+
+nock.disableNetConnect()
+
+test('registrationSignature follows documented pattern', () => {
+  const signature = GenesisClient.registrationSignature({
+    email: 'susan@linux.id',
+    username: 'susan',
+    password: 'xABC',
+    callbackClient: 'https://genesis.id/callback',
+    secret: 'abc',
+  })
+  assert.equal(signature, '5c98bce40550ec5433fca03e932d0a46')
+})
+
+test('generateQris issues request with MD5 signature', async () => {
+  const client = new GenesisClient(baseConfig)
+  const expectedSignature = GenesisClient.qrisSignature({
+    clientId: baseConfig.defaultClientId!,
+    value: '10000.00',
+    orderId: '171836274993',
+    clientSecret: baseConfig.defaultClientSecret!,
+  })
+
+  const scope = nock('https://genesis.test')
+    .post('/qrissnap2gen/v1/qr-mpm-generate-order', (body) => {
+      assert.equal(body.orderId, '171836274993')
+      assert.equal(body.value, '10000.00')
+      return true
+    })
+    .matchHeader('x-signature', expectedSignature)
+    .matchHeader('client_id', baseConfig.defaultClientId!)
+    .reply(201, {
+      qrisData: '000201010212...',
+      orderId: '171836274993',
+      TX: 'gsdbJX1K8ncXuLfxaFeg',
+      clientId: baseConfig.defaultClientId,
+    })
+
+  const resp = await client.generateQris({ orderId: '171836274993', amount: 10000 })
+  assert.equal(resp.orderId, '171836274993')
+  assert.equal(resp.tx, 'gsdbJX1K8ncXuLfxaFeg')
+  assert.equal(resp.clientId, baseConfig.defaultClientId)
+  assert.equal(resp.qrisData, '000201010212...')
+  assert.ok(scope.isDone())
+  nock.cleanAll()
+})
+
+test('queryQris posts orderId with derived signature', async () => {
+  const client = new GenesisClient(baseConfig)
+  const expectedSignature = GenesisClient.querySignature({
+    clientId: baseConfig.defaultClientId!,
+    orderId: '1718366184993',
+    clientSecret: baseConfig.defaultClientSecret!,
+  })
+
+  const scope = nock('https://genesis.test')
+    .post('/qrissnap2gen/v1/qr-mpm-query', { orderId: '1718366184993' })
+    .matchHeader('x-signature', expectedSignature)
+    .reply(200, {
+      data: {
+        transactionStatusDesc: 'Success',
+        responseCode: '2005100',
+        amount: { value: '10000.00' },
+        paidTime: '2024-07-12T14:50:23+07:00',
+      },
+      orderId: '1718366184993',
+      TX: 'gsdbJX1K8ncXuLfxaFeg',
+      clientId: baseConfig.defaultClientId,
+    })
+
+  const resp = await client.queryQris({ orderId: '1718366184993' })
+  assert.equal(resp.status, 'Success')
+  assert.equal(resp.orderId, '1718366184993')
+  assert.equal(resp.tx, 'gsdbJX1K8ncXuLfxaFeg')
+  assert.equal(resp.clientId, baseConfig.defaultClientId)
+  assert.equal(resp.paidTime, '2024-07-12T14:50:23+07:00')
+  assert.equal(resp.amount, 10000)
+  assert.ok(scope.isDone())
+  nock.cleanAll()
+})
+
+test('validateCallbackSignature accepts valid Genesis payload', () => {
+  const client = new GenesisClient(baseConfig)
+  const payload = {
+    TX: 'gsdbJX1K8ncXuLfxaFeg',
+    amountSend: 10000,
+    clientId: baseConfig.defaultClientId,
+    orderId: '1718366184993',
+    paymentStatus: 'Success',
+  }
+  const raw = JSON.stringify(payload)
+  const signature = GenesisClient.callbackSignature(payload, baseConfig.defaultClientSecret!, payload.clientId)
+  const parsed = client.validateCallbackSignature(raw, signature, baseConfig.defaultClientSecret)
+  assert.equal(parsed.paymentStatus, 'Success')
+  assert.equal(parsed.orderId, '1718366184993')
+})


### PR DESCRIPTION
## Summary
- add a dedicated Genesis client with fallback polling support and environment configuration
- route payment creation, status checks, and callbacks through Genesis when enabled while tightening withdrawal callback validation
- cover Genesis flows with unit tests for registration signature, QR creation/query, and callback signature checks

## Testing
- node --test -r ts-node/register test/genesisClient.test.ts
- node --test -r ts-node/register test/piroClient.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d7b896f76c8328b08fd1bdc469c585