### PR TITLE
Support genesis provider credentials

### DIFF
--- a/src/controller/admin/subMerchant.controller.ts
+++ b/src/controller/admin/subMerchant.controller.ts
@@ -11,7 +11,16 @@ const scheduleSchema = z.object({
 });
 const nameSchema = z.string().min(1)
 
-const providerSchema = z.enum(['hilogate', 'oy', 'netzme', '2c2p', 'gidi', 'ing1', 'piro']);
+const providerSchema = z.enum([
+  'hilogate',
+  'oy',
+  'netzme',
+  '2c2p',
+  'gidi',
+  'ing1',
+  'piro',
+  'genesis',
+]);
 
 // GET /admin/merchant/:merchantId/pg
 export async function listSubMerchants(req: Request, res: Response) {


### PR DESCRIPTION
## Summary
- allow the admin sub-merchant controller and credential normaliser to accept the new `genesis` provider with dedicated schema support
- extend the provider/payment services to load Genesis sub-merchants and prefer their credentials when Genesis QR is enabled
- treat `genesis` as a Piro variant in payment and withdrawal flows so lookups and callbacks continue to work

## Testing
- npm run build *(fails: local Prisma client lacks referenced exports)*

------
https://chatgpt.com/codex/tasks/task_e_68d7bd8d508c8328b57a6c61bb1d1838