### PR TITLE
feat: add admin loan management page

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "tsx --test src/utils/dashboard.test.ts src/utils/piroBankMap.test.ts src/pages/admin/merchants/[merchantId]/index.test.tsx"
+    "test": "tsx --test src/utils/dashboard.test.ts src/utils/piroBankMap.test.ts src/pages/admin/merchants/[merchantId]/index.test.tsx src/pages/admin/loan.test.tsx"
   },
   "dependencies": {
     "@headlessui/react": "^2.2.4",

--- a/frontend/src/components/dashboard/TransactionsTable.tsx
+++ b/frontend/src/components/dashboard/TransactionsTable.tsx
@@ -84,18 +84,22 @@ export default function TransactionsTable({
 
   const statusBadge = (s?: string) => {
     const v = (s || '').toUpperCase()
-    const map: Record<string, string> = {
-      SUCCESS: 'bg-emerald-950/40 text-emerald-300 border-emerald-900/40',
-      PAID: 'bg-indigo-950/40 text-indigo-300 border-indigo-900/40',
-      PENDING: 'bg-amber-950/40 text-amber-300 border-amber-900/40',
-      EXPIRED: 'bg-neutral-900/60 text-neutral-300 border-neutral-800',
-      DONE: 'bg-sky-950/40 text-sky-300 border-sky-900/40',
-      FAILED: 'bg-rose-950/40 text-rose-300 border-rose-900/40',
+    const map: Record<string, { className: string; label?: string }> = {
+      SUCCESS: { className: 'bg-emerald-950/40 text-emerald-300 border-emerald-900/40' },
+      PAID: { className: 'bg-indigo-950/40 text-indigo-300 border-indigo-900/40' },
+      PENDING: { className: 'bg-amber-950/40 text-amber-300 border-amber-900/40' },
+      EXPIRED: { className: 'bg-neutral-900/60 text-neutral-300 border-neutral-800' },
+      DONE: { className: 'bg-sky-950/40 text-sky-300 border-sky-900/40' },
+      FAILED: { className: 'bg-rose-950/40 text-rose-300 border-rose-900/40' },
+      LN_SETTLE: {
+        className: 'bg-purple-950/40 text-purple-200 border-purple-900/40',
+        label: 'LOAN SETTLED',
+      },
     }
-    const cls = map[v] ?? map.EXPIRED
+    const meta = map[v] ?? map.EXPIRED
     return (
-      <span className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium ${cls}`}>
-        {v || '-'}
+      <span className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium ${meta.className}`}>
+        {meta.label ?? (v || '-')}
       </span>
     )
   }
@@ -185,34 +189,35 @@ export default function TransactionsTable({
               <option value="PAID">PAID</option>
               <option value="PENDING">PENDING</option>
               <option value="EXPIRED">EXPIRED</option>
-              </select>
-            </div>
+              <option value="LN_SETTLE">LN_SETTLE</option>
+            </select>
+          </div>
 
           {/* Date range */}
           <div className="relative">
             <Calendar className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 opacity-60" size={16} />
-<DatePicker
-  selectsRange
-  startDate={dateRange[0]}
-  endDate={dateRange[1]}
-  onChange={(upd: [Date | null, Date | null] | Date | null) => {
-    const range = (upd as [Date | null, Date | null]) || [null, null]
-    setDateRange(range)
-    onDateChange(range)
-    setPage(1)
-  }}
-  isClearable
-  placeholderText="Filter tanggal…"
-  maxDate={new Date()}
-  dateFormat="dd-MM-yyyy"
-  /* ⬇️ ini kunci anti-kehalang */
-  withPortal
-  popperProps={{ strategy: 'fixed' }}
-  popperClassName="datepicker-popper"
-  calendarClassName="dp-dark"
-  className="w-full h-10 pl-9 pr-3 rounded-xl border border-neutral-800 bg-neutral-900 text-sm text-neutral-100 placeholder:text-neutral-400 focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/30 outline-none"
-/>
-</div>
+            <DatePicker
+              selectsRange
+              startDate={dateRange[0]}
+              endDate={dateRange[1]}
+              onChange={(upd: [Date | null, Date | null] | Date | null) => {
+                const range = (upd as [Date | null, Date | null]) || [null, null]
+                setDateRange(range)
+                onDateChange(range)
+                setPage(1)
+              }}
+              isClearable
+              placeholderText="Filter tanggal…"
+              maxDate={new Date()}
+              dateFormat="dd-MM-yyyy"
+              /* ⬇️ ini kunci anti-kehalang */
+              withPortal
+              popperProps={{ strategy: 'fixed' }}
+              popperClassName="datepicker-popper"
+              calendarClassName="dp-dark"
+              className="w-full h-10 pl-9 pr-3 rounded-xl border border-neutral-800 bg-neutral-900 text-sm text-neutral-100 placeholder:text-neutral-400 focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/30 outline-none"
+            />
+          </div>
 
           {/* Export */}
           <div className="flex sm:justify-end">
@@ -332,7 +337,16 @@ export default function TransactionsTable({
                         {t.feePg.toLocaleString('id-ID', { style: 'currency', currency: 'IDR' })}
                       </td>
                       <td className="px-3 py-2 text-right whitespace-nowrap font-semibold">
-                        {t.netSettle.toLocaleString('id-ID', { style: 'currency', currency: 'IDR' })}
+                        <div className="flex flex-col items-end gap-0.5">
+                          <span>
+                            {t.netSettle.toLocaleString('id-ID', { style: 'currency', currency: 'IDR' })}
+                          </span>
+                          {t.status === 'LN_SETTLE' && (
+                            <span className="text-[11px] font-normal uppercase tracking-wide text-purple-200/80">
+                              Loan Amount
+                            </span>
+                          )}
+                        </div>
                       </td>
                       <td className="px-3 py-2">{statusBadge(t.status)}</td>
                       <td className="px-3 py-2">{settlementBadge(t.settlementStatus)}</td>

--- a/frontend/src/components/layouts/AdminLayout.tsx
+++ b/frontend/src/components/layouts/AdminLayout.tsx
@@ -17,6 +17,7 @@ import {
   Wrench,
   Wallet,
   Globe,
+  Coins,
 } from 'lucide-react'
 import { motion } from 'framer-motion'
 
@@ -33,6 +34,7 @@ const navItems = [
   { label: '2FA Setup',         href: '/admin/2fa',        Icon: ShieldCheck },
   { label: 'Settings',       href: '/admin/settings',   Icon: Settings },
   { label: 'Settlement',        href: '/admin/settlement', Icon: Banknote },
+  { label: 'Loan',              href: '/admin/loan',       Icon: Coins },
   { label: 'Settlement Adjust', href: '/admin/settlement-adjust', Icon: Wrench },
   { label: 'Logs',              href: '/admin/logs',       Icon: FileText },
   { label: 'IP Whitelist',      href: '/super-admin/ip-whitelist', Icon: Globe },

--- a/frontend/src/pages/admin/loan.test.tsx
+++ b/frontend/src/pages/admin/loan.test.tsx
@@ -1,0 +1,243 @@
+import { afterEach, beforeEach, test } from 'node:test'
+import assert from 'node:assert/strict'
+import React from 'react'
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/react'
+import { JSDOM } from 'jsdom'
+
+import { LoanPageView, type LoanPageViewProps, toWibIso } from './loan'
+
+const dom = new JSDOM('<!doctype html><html><body></body></html>', { url: 'http://localhost/' })
+const { window } = dom
+
+Object.assign(globalThis, {
+  window,
+  document: window.document,
+  navigator: window.navigator,
+  HTMLElement: window.HTMLElement,
+  SVGElement: window.SVGElement,
+  Event: window.Event,
+  Node: window.Node,
+  getComputedStyle: window.getComputedStyle.bind(window),
+})
+
+if (!globalThis.requestAnimationFrame) {
+  globalThis.requestAnimationFrame = (cb: FrameRequestCallback) =>
+    setTimeout(() => cb(Date.now()), 0) as unknown as number
+}
+if (!globalThis.cancelAnimationFrame) {
+  globalThis.cancelAnimationFrame = (handle: number) => clearTimeout(handle)
+}
+
+// React Testing Library expects this flag when using React 19
+// @ts-ignore intentional global assignment
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
+type ApiCall = [string, ...any[]]
+type ApiImplementation = (...args: any[]) => Promise<any>
+
+function createApiMock() {
+  const apiMock = {
+    getCalls: [] as ApiCall[],
+    postCalls: [] as ApiCall[],
+    _getImpl: (async () => {
+      throw new Error('api.get implementation not set')
+    }) as ApiImplementation,
+    _postImpl: (async () => {
+      throw new Error('api.post implementation not set')
+    }) as ApiImplementation,
+    setGetImplementation(fn: ApiImplementation) {
+      apiMock._getImpl = fn
+    },
+    setPostImplementation(fn: ApiImplementation) {
+      apiMock._postImpl = fn
+    },
+    async get(...args: any[]) {
+      apiMock.getCalls.push(args as ApiCall)
+      return apiMock._getImpl(...args)
+    },
+    async post(...args: any[]) {
+      apiMock.postCalls.push(args as ApiCall)
+      return apiMock._postImpl(...args)
+    },
+    reset() {
+      apiMock.getCalls = []
+      apiMock.postCalls = []
+      apiMock._getImpl = (async () => {
+        throw new Error('api.get implementation not set')
+      }) as ApiImplementation
+      apiMock._postImpl = (async () => {
+        throw new Error('api.post implementation not set')
+      }) as ApiImplementation
+    },
+  }
+
+  return apiMock
+}
+
+const apiMock = createApiMock()
+
+const defaultProps: LoanPageViewProps = {
+  apiClient: apiMock as unknown as LoanPageViewProps['apiClient'],
+}
+
+beforeEach(() => {
+  apiMock.reset()
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+test('loads sub-merchant options on mount', async () => {
+  apiMock.setGetImplementation(async (url: string) => {
+    if (url === '/admin/merchants/all/balances') {
+      return {
+        data: {
+          subBalances: [
+            { id: 'sub-1', name: 'Sub One', provider: 'oy', balance: 0 },
+            { id: 'sub-2', name: 'Sub Two', provider: 'oy', balance: 0 },
+          ],
+        },
+      }
+    }
+    throw new Error(`Unhandled GET ${url}`)
+  })
+
+  const { findByLabelText } = render(<LoanPageView {...defaultProps} />)
+  const select = (await findByLabelText('Sub-merchant')) as HTMLSelectElement
+
+  await waitFor(() => {
+    assert.equal(select.options.length, 3)
+  })
+
+  assert.deepEqual(apiMock.getCalls[0], ['/admin/merchants/all/balances'])
+})
+
+test('fetches transactions with WIB date parameters', async () => {
+  const start = new Date('2024-01-02T00:00:00Z')
+  const end = new Date('2024-01-03T00:00:00Z')
+
+  let capturedParams: any = null
+  apiMock.setGetImplementation(async (url: string, config?: any) => {
+    if (url === '/admin/merchants/all/balances') {
+      return { data: { subBalances: [{ id: 'sub-1', name: 'Sub One', provider: 'oy', balance: 0 }] } }
+    }
+    if (url === '/admin/loan/transactions') {
+      capturedParams = config?.params
+      return {
+        data: {
+          data: [
+            {
+              id: 'order-1',
+              amount: 10000,
+              pendingAmount: 5000,
+              status: 'PAID',
+              createdAt: new Date('2024-01-02T03:00:00Z').toISOString(),
+              loanedAt: null,
+              loanAmount: null,
+              loanCreatedAt: null,
+            },
+          ],
+        },
+      }
+    }
+    throw new Error(`Unhandled GET ${url}`)
+  })
+
+  const { findByLabelText, getByRole, findByText } = render(
+    <LoanPageView {...defaultProps} initialRange={[start, end]} />
+  )
+
+  const select = (await findByLabelText('Sub-merchant')) as HTMLSelectElement
+  fireEvent.change(select, { target: { value: 'sub-1' } })
+
+  const loadButton = getByRole('button', { name: 'Muat Transaksi' })
+  fireEvent.click(loadButton)
+
+  await findByText('order-1')
+
+  assert.ok(capturedParams)
+  assert.equal(capturedParams.subMerchantId, 'sub-1')
+  assert.equal(capturedParams.startDate, toWibIso(start))
+  assert.equal(capturedParams.endDate, toWibIso(end))
+})
+
+test('submits selected transactions to settle API', async () => {
+  const start = new Date('2024-01-02T00:00:00Z')
+  const end = new Date('2024-01-03T00:00:00Z')
+
+  let loanFetchCount = 0
+  apiMock.setGetImplementation(async (url: string, config?: any) => {
+    if (url === '/admin/merchants/all/balances') {
+      return { data: { subBalances: [{ id: 'sub-1', name: 'Sub One', provider: 'oy', balance: 0 }] } }
+    }
+    if (url === '/admin/loan/transactions') {
+      loanFetchCount += 1
+      if (loanFetchCount === 1) {
+        return {
+          data: {
+            data: [
+              {
+                id: 'order-1',
+                amount: 10000,
+                pendingAmount: 5000,
+                status: 'PAID',
+                createdAt: new Date('2024-01-02T03:00:00Z').toISOString(),
+                loanedAt: null,
+                loanAmount: null,
+                loanCreatedAt: null,
+              },
+            ],
+          },
+        }
+      }
+      return {
+        data: {
+          data: [
+            {
+              id: 'order-1',
+              amount: 10000,
+              pendingAmount: 0,
+              status: 'LN_SETTLE',
+              createdAt: new Date('2024-01-02T03:00:00Z').toISOString(),
+              loanedAt: new Date('2024-01-03T02:00:00Z').toISOString(),
+              loanAmount: 5000,
+              loanCreatedAt: new Date('2024-01-03T02:00:00Z').toISOString(),
+            },
+          ],
+        },
+      }
+    }
+    throw new Error(`Unhandled GET ${url}`)
+  })
+
+  apiMock.setPostImplementation(async () => ({ data: { processed: 1 } }))
+
+  const { findByLabelText, getByRole, findByText } = render(
+    <LoanPageView {...defaultProps} initialRange={[start, end]} />
+  )
+
+  const select = (await findByLabelText('Sub-merchant')) as HTMLSelectElement
+  fireEvent.change(select, { target: { value: 'sub-1' } })
+
+  fireEvent.click(getByRole('button', { name: 'Muat Transaksi' }))
+  await findByText('order-1')
+
+  const checkbox = await findByLabelText('Pilih transaksi order-1')
+  fireEvent.click(checkbox)
+
+  fireEvent.click(getByRole('button', { name: 'Settle Loan' }))
+
+  await waitFor(() => {
+    assert.ok(apiMock.postCalls.length > 0)
+  })
+
+  assert.deepEqual(apiMock.postCalls[0], [
+    '/admin/loan/settle',
+    { subMerchantId: 'sub-1', orderIds: ['order-1'] },
+  ])
+
+  await waitFor(() => {
+    assert.ok(apiMock.getCalls.filter(call => call[0] === '/admin/loan/transactions').length >= 2)
+  })
+})

--- a/frontend/src/pages/admin/loan.tsx
+++ b/frontend/src/pages/admin/loan.tsx
@@ -1,0 +1,466 @@
+'use client'
+
+import React, { useEffect, useMemo, useState } from 'react'
+import DatePicker from 'react-datepicker'
+import dayjs from 'dayjs'
+import utc from 'dayjs/plugin/utc'
+import timezone from 'dayjs/plugin/timezone'
+import { AlertCircle, CheckCircle, Loader2, RefreshCcw } from 'lucide-react'
+
+import api from '@/lib/api'
+import { useRequireAuth } from '@/hooks/useAuth'
+import type { SubBalance } from '@/types/dashboard'
+
+dayjs.extend(utc)
+dayjs.extend(timezone)
+
+if (typeof window !== 'undefined') {
+  void import('react-datepicker/dist/react-datepicker.css')
+}
+
+export const toWibIso = (date: Date) => dayjs(date).tz('Asia/Jakarta', true).toDate().toISOString()
+
+type LoanTransaction = {
+  id: string
+  amount: number
+  pendingAmount: number
+  status: 'PAID' | 'LN_SETTLE'
+  createdAt: string
+  loanedAt: string | null
+  loanAmount: number | null
+  loanCreatedAt: string | null
+}
+
+export interface LoanPageViewProps {
+  apiClient?: typeof api
+  initialRange?: [Date | null, Date | null]
+}
+
+const formatCurrency = (value: number) =>
+  value.toLocaleString('id-ID', { style: 'currency', currency: 'IDR' })
+
+const formatDateTime = (value: string | null) =>
+  value
+    ? new Date(value).toLocaleString('id-ID', {
+        dateStyle: 'short',
+        timeStyle: 'short',
+      })
+    : '-'
+
+function LoanStatusBadge({ status }: { status: LoanTransaction['status'] }) {
+  const meta =
+    status === 'LN_SETTLE'
+      ? {
+          label: 'Loan Settled',
+          className:
+            'bg-purple-950/40 text-purple-200 border border-purple-900/40',
+        }
+      : {
+          label: 'Paid',
+          className: 'bg-indigo-950/40 text-indigo-300 border border-indigo-900/40',
+        }
+
+  return (
+    <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium uppercase ${meta.className}`}>
+      {meta.label}
+    </span>
+  )
+}
+
+export function LoanPageView({ apiClient = api, initialRange }: LoanPageViewProps) {
+  const [subMerchants, setSubMerchants] = useState<SubBalance[]>([])
+  const [loadingSubs, setLoadingSubs] = useState(true)
+  const [subsError, setSubsError] = useState('')
+  const [selectedSub, setSelectedSub] = useState('')
+
+  const [dateRange, setDateRange] = useState<[Date | null, Date | null]>(() => {
+    if (initialRange) return initialRange
+    const end = new Date()
+    const start = new Date()
+    start.setDate(start.getDate() - 6)
+    return [start, end]
+  })
+  const [transactions, setTransactions] = useState<LoanTransaction[]>([])
+  const [loadingTx, setLoadingTx] = useState(false)
+  const [txError, setTxError] = useState('')
+  const [formError, setFormError] = useState('')
+
+  const [selectedOrders, setSelectedOrders] = useState<string[]>([])
+  const [submitting, setSubmitting] = useState(false)
+  const [actionMessage, setActionMessage] = useState('')
+  const [actionError, setActionError] = useState('')
+
+  const [startDate, endDate] = dateRange
+
+  useEffect(() => {
+    let cancelled = false
+    async function fetchSubMerchants() {
+      setSubsError('')
+      setLoadingSubs(true)
+      try {
+        const { data } = await apiClient.get<{ subBalances: SubBalance[] }>(
+          '/admin/merchants/all/balances'
+        )
+        if (cancelled) return
+        setSubMerchants(data.subBalances ?? [])
+      } catch (err: any) {
+        if (cancelled) return
+        setSubsError(err?.response?.data?.error ?? 'Gagal memuat daftar sub-merchant')
+      } finally {
+        if (cancelled) return
+        setLoadingSubs(false)
+      }
+    }
+    fetchSubMerchants()
+    return () => {
+      cancelled = true
+    }
+  }, [apiClient])
+
+  useEffect(() => {
+    setSelectedOrders(prev =>
+      prev.filter(id => transactions.some(tx => tx.id === id && tx.status === 'PAID'))
+    )
+  }, [transactions])
+
+  const selectableIds = useMemo(
+    () => transactions.filter(tx => tx.status === 'PAID').map(tx => tx.id),
+    [transactions]
+  )
+
+  const totalPending = useMemo(
+    () => transactions.reduce((sum, tx) => sum + (tx.pendingAmount ?? 0), 0),
+    [transactions]
+  )
+  const totalLoanAmount = useMemo(
+    () => transactions.reduce((sum, tx) => sum + (tx.loanAmount ?? 0), 0),
+    [transactions]
+  )
+  const selectedSummary = useMemo(() => {
+    return transactions.reduce(
+      (acc, tx) => {
+        if (selectedOrders.includes(tx.id)) {
+          acc.count += 1
+          acc.pending += tx.pendingAmount ?? 0
+          acc.loan += tx.loanAmount ?? 0
+        }
+        return acc
+      },
+      { count: 0, pending: 0, loan: 0 }
+    )
+  }, [selectedOrders, transactions])
+
+  const loadTransactions = async () => {
+    setFormError('')
+    setTxError('')
+
+    if (!selectedSub) {
+      setFormError('Pilih sub-merchant terlebih dahulu.')
+      return
+    }
+    if (!startDate || !endDate) {
+      setFormError('Pilih rentang tanggal terlebih dahulu.')
+      return
+    }
+
+    setLoadingTx(true)
+    try {
+      const params = {
+        subMerchantId: selectedSub,
+        startDate: toWibIso(startDate),
+        endDate: toWibIso(endDate),
+      }
+      const { data } = await apiClient.get<{ data: any[] }>('/admin/loan/transactions', {
+        params,
+      })
+
+      const mapped: LoanTransaction[] = (data.data || []).map((raw) => ({
+        id: raw.id,
+        amount: raw.amount ?? 0,
+        pendingAmount: raw.pendingAmount ?? 0,
+        status: raw.status === 'LN_SETTLE' ? 'LN_SETTLE' : 'PAID',
+        createdAt: raw.createdAt,
+        loanedAt: raw.loanedAt ?? null,
+        loanAmount: raw.loanAmount ?? null,
+        loanCreatedAt: raw.loanCreatedAt ?? null,
+      }))
+
+      setTransactions(mapped)
+      setSelectedOrders([])
+    } catch (err: any) {
+      setTxError(err?.response?.data?.error ?? 'Gagal memuat transaksi loan')
+    } finally {
+      setLoadingTx(false)
+    }
+  }
+
+  const toggleAll = (checked: boolean) => {
+    if (checked) {
+      setSelectedOrders(selectableIds)
+    } else {
+      setSelectedOrders([])
+    }
+  }
+
+  const toggleOne = (id: string, checked: boolean, disabled: boolean) => {
+    if (disabled) return
+    setSelectedOrders(prev =>
+      checked ? [...prev, id] : prev.filter(item => item !== id)
+    )
+  }
+
+  const settleSelected = async () => {
+    setFormError('')
+    setActionError('')
+
+    if (!selectedSub) {
+      setFormError('Pilih sub-merchant terlebih dahulu.')
+      return
+    }
+    if (selectedOrders.length === 0) {
+      setFormError('Pilih minimal satu transaksi berstatus PAID.')
+      return
+    }
+
+    setSubmitting(true)
+    try {
+      const settledCount = selectedOrders.length
+      await apiClient.post('/admin/loan/settle', {
+        subMerchantId: selectedSub,
+        orderIds: selectedOrders,
+      })
+      await loadTransactions()
+      setActionMessage(`Berhasil mengirim permintaan settle untuk ${settledCount} transaksi`)
+    } catch (err: any) {
+      setActionError(err?.response?.data?.error ?? 'Gagal mengirim permintaan settle')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const handleLoadTransactions = () => {
+    setActionError('')
+    setActionMessage('')
+    void loadTransactions()
+  }
+
+  return (
+    <div className="dark min-h-screen bg-neutral-950 text-neutral-100 p-4 sm:p-6">
+      <div className="mx-auto flex max-w-6xl flex-col gap-4">
+        <header className="space-y-1">
+          <h1 className="text-xl font-semibold">Loan Management</h1>
+          <p className="text-sm text-neutral-400">
+            Pantau dan settle transaksi loan untuk sub-merchant terpilih.
+          </p>
+        </header>
+
+        {subsError && (
+          <div className="inline-flex items-center gap-2 rounded-lg border border-rose-900/40 bg-rose-950/40 px-3 py-2 text-sm text-rose-200">
+            <AlertCircle size={16} /> {subsError}
+          </div>
+        )}
+
+        <section className="rounded-2xl border border-neutral-800 bg-neutral-900/70 shadow-sm">
+          <div className="space-y-4 p-4 sm:p-5">
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-[minmax(0,2fr)_minmax(0,2fr)_minmax(0,1fr)]">
+              <div className="flex flex-col gap-1">
+                <label htmlFor="loan-sub-merchant" className="text-sm font-medium">
+                  Sub-merchant
+                </label>
+                <select
+                  id="loan-sub-merchant"
+                  value={selectedSub}
+                  onChange={event => setSelectedSub(event.target.value)}
+                  disabled={loadingSubs}
+                  className="h-10 rounded-xl border border-neutral-800 bg-neutral-900 px-3 text-sm text-neutral-100 focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/30 outline-none disabled:opacity-60"
+                >
+                  <option value="">Pilih sub-merchant…</option>
+                  {subMerchants.map(sub => (
+                    <option key={sub.id} value={sub.id}>
+                      {sub.name || sub.id}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <div className="flex flex-col gap-1">
+                <label htmlFor="loan-date-range" className="text-sm font-medium">
+                  Rentang tanggal (WIB)
+                </label>
+                <DatePicker
+                  id="loan-date-range"
+                  selectsRange
+                  startDate={startDate}
+                  endDate={endDate}
+                  onChange={(range: [Date | null, Date | null] | Date | null) => {
+                    const [start, end] = (range as [Date | null, Date | null]) || [null, null]
+                    setDateRange([start, end])
+                  }}
+                  withPortal
+                  isClearable
+                  maxDate={new Date()}
+                  dateFormat="dd-MM-yyyy"
+                  placeholderText="Pilih rentang tanggal"
+                  className="h-10 w-full rounded-xl border border-neutral-800 bg-neutral-900 px-3 text-sm text-neutral-100 placeholder:text-neutral-400 focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/30 outline-none"
+                />
+              </div>
+
+              <div className="flex flex-col justify-end gap-2 sm:flex-row sm:items-end">
+                <button
+                  type="button"
+                  onClick={handleLoadTransactions}
+                  disabled={loadingSubs || submitting}
+                  className="inline-flex items-center justify-center gap-2 rounded-xl border border-neutral-800 px-3 py-2.5 text-sm font-medium transition hover:bg-neutral-800/60 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {loadingTx ? <Loader2 className="animate-spin" size={16} /> : <RefreshCcw size={16} />}
+                  Muat Transaksi
+                </button>
+              </div>
+            </div>
+
+            {formError && (
+              <div className="inline-flex items-center gap-2 text-sm text-amber-300">
+                <AlertCircle size={16} /> {formError}
+              </div>
+            )}
+
+            {(actionMessage || actionError) && (
+              <div className="space-y-2" aria-live="polite">
+                {actionMessage && (
+                  <div className="inline-flex items-center gap-2 rounded-lg border border-emerald-900/40 bg-emerald-950/40 px-3 py-2 text-sm text-emerald-200">
+                    <CheckCircle size={16} /> {actionMessage}
+                  </div>
+                )}
+                {actionError && (
+                  <div className="inline-flex items-center gap-2 rounded-lg border border-rose-900/40 bg-rose-950/40 px-3 py-2 text-sm text-rose-200">
+                    <AlertCircle size={16} /> {actionError}
+                  </div>
+                )}
+              </div>
+            )}
+
+            {txError && (
+              <div className="inline-flex items-center gap-2 rounded-lg border border-rose-900/40 bg-rose-950/40 px-3 py-2 text-sm text-rose-200">
+                <AlertCircle size={16} /> {txError}
+              </div>
+            )}
+
+            <div className="flex flex-wrap items-center gap-3 text-sm text-neutral-300">
+              <span>
+                Total data: <strong>{transactions.length}</strong>
+              </span>
+              <span>
+                Pending amount: <strong>{formatCurrency(totalPending)}</strong>
+              </span>
+              <span>
+                Loan amount: <strong>{formatCurrency(totalLoanAmount)}</strong>
+              </span>
+              <span>
+                Dipilih: <strong>{selectedSummary.count}</strong>
+              </span>
+              <span>
+                Pending terpilih: <strong>{formatCurrency(selectedSummary.pending)}</strong>
+              </span>
+              <span>
+                Loan terpilih: <strong>{formatCurrency(selectedSummary.loan)}</strong>
+              </span>
+            </div>
+
+            <div className="overflow-x-auto">
+              <table className="min-w-[960px] w-full text-sm">
+                <thead>
+                  <tr className="border-b border-neutral-800 bg-neutral-900/60">
+                    <th className="px-3 py-2 text-left">
+                      <input
+                        type="checkbox"
+                        aria-label="Pilih semua transaksi PAID"
+                        checked={selectableIds.length > 0 && selectedOrders.length === selectableIds.length}
+                        onChange={event => toggleAll(event.target.checked)}
+                        disabled={selectableIds.length === 0}
+                      />
+                    </th>
+                    <th className="px-3 py-2 text-left">Order ID</th>
+                    <th className="px-3 py-2 text-left">Dibuat</th>
+                    <th className="px-3 py-2 text-left">Nominal</th>
+                    <th className="px-3 py-2 text-left">Pending Amount</th>
+                    <th className="px-3 py-2 text-left">Loan Amount</th>
+                    <th className="px-3 py-2 text-left">Loan Created</th>
+                    <th className="px-3 py-2 text-left">Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {loadingTx ? (
+                    <tr>
+                      <td colSpan={8} className="px-3 py-6 text-center text-sm text-neutral-400">
+                        <div className="inline-flex items-center gap-2">
+                          <Loader2 className="animate-spin" size={16} /> Memuat transaksi…
+                        </div>
+                      </td>
+                    </tr>
+                  ) : transactions.length === 0 ? (
+                    <tr>
+                      <td colSpan={8} className="px-3 py-6 text-center text-sm text-neutral-400">
+                        Tidak ada data untuk filter saat ini.
+                      </td>
+                    </tr>
+                  ) : (
+                    transactions.map(tx => {
+                      const disabled = tx.status !== 'PAID'
+                      const checked = selectedOrders.includes(tx.id)
+                      return (
+                        <tr key={tx.id} className="border-b border-neutral-800 last:border-0">
+                          <td className="px-3 py-2">
+                            <input
+                              type="checkbox"
+                              aria-label={`Pilih transaksi ${tx.id}`}
+                              checked={checked}
+                              onChange={event => toggleOne(tx.id, event.target.checked, disabled)}
+                              disabled={disabled}
+                            />
+                          </td>
+                          <td className="px-3 py-2 font-mono text-xs">{tx.id}</td>
+                          <td className="px-3 py-2 whitespace-nowrap">{formatDateTime(tx.createdAt)}</td>
+                          <td className="px-3 py-2 whitespace-nowrap">{formatCurrency(tx.amount)}</td>
+                          <td className="px-3 py-2 whitespace-nowrap">{formatCurrency(tx.pendingAmount)}</td>
+                          <td className="px-3 py-2 whitespace-nowrap">
+                            {tx.loanAmount != null ? formatCurrency(tx.loanAmount) : '-'}
+                          </td>
+                          <td className="px-3 py-2 whitespace-nowrap">
+                            {formatDateTime(tx.loanCreatedAt ?? tx.loanedAt)}
+                          </td>
+                          <td className="px-3 py-2">
+                            <LoanStatusBadge status={tx.status} />
+                          </td>
+                        </tr>
+                      )
+                    })
+                  )}
+                </tbody>
+              </table>
+            </div>
+
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+              <div className="text-xs text-neutral-400">
+                Hanya transaksi berstatus <strong>PAID</strong> yang dapat disettle menjadi loan.
+              </div>
+              <button
+                type="button"
+                onClick={settleSelected}
+                disabled={submitting || selectedOrders.length === 0}
+                className="inline-flex items-center justify-center gap-2 rounded-xl border border-purple-900/50 bg-purple-950/30 px-3 py-2.5 text-sm font-medium text-purple-100 transition hover:bg-purple-900/40 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {submitting ? <Loader2 className="animate-spin" size={16} /> : null}
+                Settle Loan
+              </button>
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
+  )
+}
+
+export default function LoanPage() {
+  useRequireAuth()
+  return <LoanPageView />
+}

--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -458,7 +458,7 @@ export default function DashboardPage() {
       setTotalPages(Math.max(1, Math.ceil(data.total / perPage)))
       setTotalTrans(data.totalPaid)
 
-      const VALID_STATUSES: Tx['status'][] = ['SUCCESS', 'PENDING', 'EXPIRED', 'DONE', 'PAID']
+      const VALID_STATUSES: Tx['status'][] = ['SUCCESS', 'PENDING', 'EXPIRED', 'DONE', 'PAID', 'LN_SETTLE']
 
       const mapped: Tx[] = data.transactions.map(o => {
         const raw = o.status ?? ''

--- a/frontend/src/types/dashboard.ts
+++ b/frontend/src/types/dashboard.ts
@@ -7,7 +7,7 @@ export type Tx = {
   feeLauncx: number
   feePg: number
   netSettle: number
-  status: '' | 'SUCCESS' | 'PENDING' | 'EXPIRED' | 'DONE' | 'PAID'
+  status: '' | 'SUCCESS' | 'PENDING' | 'EXPIRED' | 'DONE' | 'PAID' | 'LN_SETTLE'
   settlementStatus: string
   channel: string
   paymentReceivedTime?: string


### PR DESCRIPTION
## Summary
- add Loan navigation entry and support for LN_SETTLE across dashboard status handling
- implement loan management page with WIB-aware filters, loan settlement actions, and validation
- cover loan workflows with node:test suite and extend frontend test runner to include the new tests

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d9ff0629848328aaf19ce5da2949b0