### PR TITLE
Fix Next.js build by adding CSS declaration and relocating tests

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,6 +1,24 @@
 import type { NextConfig } from 'next'
 import path from 'path'
 
+// Temporary workaround for Next.js builds failing because `WebpackError` is not
+// exported from the bundled webpack runtime. This ensures the class exists so
+// the built-in minify plugin can instantiate it without throwing.
+const webpackRuntime = require('next/dist/compiled/webpack/webpack.js') as {
+  WebpackError?: ErrorConstructor
+}
+
+if (typeof webpackRuntime.WebpackError !== 'function') {
+  class PatchedWebpackError extends Error {
+    constructor(message?: string) {
+      super(message)
+      this.name = 'WebpackError'
+    }
+  }
+
+  webpackRuntime.WebpackError = PatchedWebpackError as ErrorConstructor
+}
+
 const nextConfig: NextConfig = {
   reactStrictMode: true,
   outputFileTracingRoot: path.resolve(__dirname, '..'),

--- a/frontend/src/pages/admin/merchants/[merchantId]/index.tsx
+++ b/frontend/src/pages/admin/merchants/[merchantId]/index.tsx
@@ -1112,3 +1112,7 @@ export function PaymentProvidersPageView({
     </div>
   )
 }
+
+export default function PaymentProvidersPage(props: PaymentProvidersPageProps) {
+  return <PaymentProvidersPageView {...props} />
+}

--- a/frontend/src/tests/loan.test.tsx
+++ b/frontend/src/tests/loan.test.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 import { cleanup, fireEvent, render, waitFor } from '@testing-library/react'
 import { JSDOM } from 'jsdom'
 
-import { LoanPageView, type LoanPageViewProps, toWibIso } from './loan'
+import { LoanPageView, type LoanPageViewProps, toWibIso } from '../pages/admin/loan'
 
 const dom = new JSDOM('<!doctype html><html><body></body></html>', { url: 'http://localhost/' })
 const { window } = dom

--- a/frontend/src/tests/merchants/merchant-index.test.tsx
+++ b/frontend/src/tests/merchants/merchant-index.test.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 import { cleanup, fireEvent, render, waitFor } from '@testing-library/react'
 import { act } from 'react'
 import { JSDOM } from 'jsdom'
-import { PaymentProvidersPageView, type PaymentProvidersPageProps } from './index'
+import { PaymentProvidersPageView, type PaymentProvidersPageProps } from '../../pages/admin/merchants/[merchantId]/index'
 
 const dom = new JSDOM('<!doctype html><html><body></body></html>', { url: 'http://localhost/' })
 const { window } = dom

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -21,6 +21,13 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "postcss.config.js", "tailwind.config.js"],
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    "**/*.d.ts",
+    "postcss.config.js",
+    "tailwind.config.js"
+  ],
   "exclude": ["node_modules"]
 }

--- a/frontend/types/react-datepicker-css.d.ts
+++ b/frontend/types/react-datepicker-css.d.ts
@@ -1,0 +1,1 @@
+declare module 'react-datepicker/dist/react-datepicker.css';


### PR DESCRIPTION
## Summary
- add a declaration file for the react-datepicker CSS bundle and include declaration files in the frontend tsconfig
- patch next.config to polyfill the missing WebpackError export during builds and ensure the merchant page exports a default component
- relocate page-specific tests out of the pages directory so Next.js no longer tries to bundle them during production builds

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da039d7850832889f21f9c1c99b11b