### PR TITLE
Add compound index for Order loan queries

### DIFF
--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -241,6 +241,7 @@ model Order {
   @@index([partnerClientId])
   @@index([createdAt])
   @@index([status])
+  @@index([subMerchantId, createdAt])
 }
 
 model LoanEntry {


### PR DESCRIPTION
## Summary
- add a compound index on `Order` covering `subMerchantId` and `createdAt` to better match loan transaction filters

## Testing
- `npx prisma migrate dev --name add_order_submerchant_created_idx --schema src/prisma/schema.prisma` *(fails: missing `DATABASE_URL` environment variable in the current container)*

------
https://chatgpt.com/codex/tasks/task_e_68da11d0bea8832899606eea892285d2