### PR TITLE
Add compound index for loan transactions lookup

### DIFF
--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -241,7 +241,7 @@ model Order {
   @@index([partnerClientId])
   @@index([createdAt])
   @@index([status])
-  @@index([subMerchantId, createdAt])
+  @@index([subMerchantId, status, createdAt])
 }
 
 model LoanEntry {


### PR DESCRIPTION
## Summary
- add a compound index on the Prisma Order model covering subMerchantId, status, and createdAt to better support the loan transactions query

## Testing
- not run (schema change only)


------
https://chatgpt.com/codex/tasks/task_e_68da10ba25a083289969106bd96f40dc