### PR TITLE
Update loan tests to mock /admin/merchants routes

### DIFF
--- a/frontend/src/tests/loan.test.tsx
+++ b/frontend/src/tests/loan.test.tsx
@@ -80,6 +80,9 @@ function createApiMock() {
 }
 
 const apiMock = createApiMock()
+const BALANCES_PATH = '/admin/merchants/all/balances'
+const LOAN_TRANSACTIONS_PATH = '/admin/merchants/loan/transactions'
+const LOAN_SETTLE_PATH = '/admin/merchants/loan/settle'
 
 const defaultProps: LoanPageViewProps = {
   apiClient: apiMock as unknown as LoanPageViewProps['apiClient'],
@@ -95,7 +98,7 @@ afterEach(() => {
 
 test('loads sub-merchant options on mount', async () => {
   apiMock.setGetImplementation(async (url: string) => {
-    if (url === '/admin/merchants/all/balances') {
+    if (url === BALANCES_PATH) {
       return {
         data: {
           subBalances: [
@@ -115,7 +118,7 @@ test('loads sub-merchant options on mount', async () => {
     assert.equal(select.options.length, 3)
   })
 
-  assert.deepEqual(apiMock.getCalls[0], ['/admin/merchants/all/balances'])
+  assert.deepEqual(apiMock.getCalls[0], [BALANCES_PATH])
 })
 
 test('fetches transactions with WIB date parameters', async () => {
@@ -124,10 +127,10 @@ test('fetches transactions with WIB date parameters', async () => {
 
   let capturedParams: any = null
   apiMock.setGetImplementation(async (url: string, config?: any) => {
-    if (url === '/admin/merchants/all/balances') {
+    if (url === BALANCES_PATH) {
       return { data: { subBalances: [{ id: 'sub-1', name: 'Sub One', provider: 'oy', balance: 0 }] } }
     }
-    if (url === '/admin/merchants/loan/transactions') {
+    if (url === LOAN_TRANSACTIONS_PATH) {
       capturedParams = config?.params
       return {
         data: {
@@ -176,10 +179,10 @@ test('submits selected transactions to settle API', async () => {
 
   let loanFetchCount = 0
   apiMock.setGetImplementation(async (url: string, config?: any) => {
-    if (url === '/admin/merchants/all/balances') {
+    if (url === BALANCES_PATH) {
       return { data: { subBalances: [{ id: 'sub-1', name: 'Sub One', provider: 'oy', balance: 0 }] } }
     }
-    if (url === '/admin/merchants/loan/transactions') {
+    if (url === LOAN_TRANSACTIONS_PATH) {
       loanFetchCount += 1
       if (loanFetchCount === 1) {
         return {
@@ -243,13 +246,13 @@ test('submits selected transactions to settle API', async () => {
   })
 
   assert.deepEqual(apiMock.postCalls[0], [
-    '/admin/merchants/loan/settle',
+    LOAN_SETTLE_PATH,
     { subMerchantId: 'sub-1', orderIds: ['order-1'] },
   ])
 
   await waitFor(() => {
     assert.ok(
-      apiMock.getCalls.filter(call => call[0] === '/admin/merchants/loan/transactions').length >= 2,
+      apiMock.getCalls.filter(call => call[0] === LOAN_TRANSACTIONS_PATH).length >= 2,
     )
   })
 })
@@ -260,10 +263,10 @@ test('allows loading additional loan transaction pages', async () => {
 
   let lastParams: any = null
   apiMock.setGetImplementation(async (url: string, config?: any) => {
-    if (url === '/admin/merchants/all/balances') {
+    if (url === BALANCES_PATH) {
       return { data: { subBalances: [{ id: 'sub-1', name: 'Sub One', provider: 'oy', balance: 0 }] } }
     }
-    if (url === '/admin/merchants/loan/transactions') {
+    if (url === LOAN_TRANSACTIONS_PATH) {
       lastParams = config?.params
       if (config?.params?.page === 1) {
         return {

--- a/test/adminLoan.routes.test.ts
+++ b/test/adminLoan.routes.test.ts
@@ -74,12 +74,12 @@ test('getLoanTransactions filters by WIB range and formats response', async () =
   };
 
   const app = express();
-  app.get('/admin/loan/transactions', (req, res) =>
+  app.get('/admin/merchants/loan/transactions', (req, res) =>
     getLoanTransactions(req as any, res),
   );
 
   const res = await request(app)
-    .get('/admin/loan/transactions')
+    .get('/admin/merchants/loan/transactions')
     .query({
       subMerchantId: 'sub-1',
       startDate: '2024-05-01',
@@ -144,12 +144,12 @@ test('getLoanTransactions enforces maximum page size', async () => {
   };
 
   const app = express();
-  app.get('/admin/loan/transactions', (req, res) =>
+  app.get('/admin/merchants/loan/transactions', (req, res) =>
     getLoanTransactions(req as any, res),
   );
 
   const res = await request(app)
-    .get('/admin/loan/transactions')
+    .get('/admin/merchants/loan/transactions')
     .query({
       subMerchantId: 'sub-9',
       startDate: '2024-05-01',
@@ -189,13 +189,13 @@ test('settleLoanOrders migrates PAID orders to loan entries', async () => {
 
   const app = express();
   app.use(express.json());
-  app.post('/admin/loan/settle', (req, res) => {
+  app.post('/admin/merchants/loan/settle', (req, res) => {
     (req as any).userId = 'admin-123';
     settleLoanOrders(req as any, res);
   });
 
   const res = await request(app)
-    .post('/admin/loan/settle')
+    .post('/admin/merchants/loan/settle')
     .send({ subMerchantId: 'sub-2', orderIds: ['ord-5'] });
 
   assert.equal(res.status, 200);


### PR DESCRIPTION
## Summary
- adjust the frontend loan test helpers to reference the /admin/merchants loan endpoints via shared constants
- update the admin loan route tests to expect the /admin/merchants loan and settle paths

## Testing
- npx tsx --test src/tests/loan.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68da2092973c8328a5a8eb25cf9123e2