### PR TITLE
feat: expand admin loan batch size

### DIFF
--- a/src/controller/admin/loan.controller.ts
+++ b/src/controller/admin/loan.controller.ts
@@ -7,7 +7,12 @@ import { AuthRequest } from '../../middleware/auth';
 import { logAdminAction } from '../../util/adminLog';
 import { wibTimestamp } from '../../util/time';
 
-const MAX_PAGE_SIZE = 100;
+const MAX_CONFIGURED_PAGE_SIZE = 1500;
+const configuredMaxPageSize = Number(process.env.LOAN_MAX_PAGE_SIZE);
+const MAX_PAGE_SIZE =
+  Number.isFinite(configuredMaxPageSize) && configuredMaxPageSize >= 1
+    ? Math.min(configuredMaxPageSize, MAX_CONFIGURED_PAGE_SIZE)
+    : MAX_CONFIGURED_PAGE_SIZE;
 const DEFAULT_PAGE_SIZE = 50;
 
 const loanQuerySchema = z.object({

--- a/test/adminLoan.routes.test.ts
+++ b/test/adminLoan.routes.test.ts
@@ -134,8 +134,8 @@ test('getLoanTransactions filters by WIB range and formats response', async () =
 
 test('getLoanTransactions enforces maximum page size', async () => {
   prisma.order.findMany = async (args: any) => {
-    assert.equal(args.take, 100);
-    assert.equal(args.skip, 100);
+    assert.equal(args.take, 1500);
+    assert.equal(args.skip, 1500);
     return [];
   };
   prisma.order.count = async (args: any) => {
@@ -155,14 +155,14 @@ test('getLoanTransactions enforces maximum page size', async () => {
       startDate: '2024-05-01',
       endDate: '2024-05-03',
       page: 2,
-      pageSize: 500,
+      pageSize: 5000,
     });
 
   assert.equal(res.status, 200);
   assert.deepEqual(res.body.meta, {
     total: 0,
     page: 2,
-    pageSize: 100,
+    pageSize: 1500,
   });
 });
 


### PR DESCRIPTION
## Summary
- allow the loan transactions controller to serve up to 1,500 records while keeping an upper bound configurable via `LOAN_MAX_PAGE_SIZE`
- update the admin loan UI to default to 1,500 rows per fetch, expose a batch selector, and highlight how many items are selected for bulk settlement
- extend backend and frontend tests to cover the new pagination ceiling and verify all selected IDs are submitted during bulk settle

## Testing
- node --test -r ts-node/register test/adminLoan.routes.test.ts
- (cd frontend && npx tsx --test src/tests/loan.test.tsx)


------
https://chatgpt.com/codex/tasks/task_e_68da27a69dac8328b3012bd309904c2d