### PR TITLE
Restrict default loan transactions to paid orders

### DIFF
--- a/frontend/src/pages/admin/loan.tsx
+++ b/frontend/src/pages/admin/loan.tsx
@@ -101,6 +101,7 @@ export function LoanPageView({ apiClient = api, initialRange }: LoanPageViewProp
   const [lastLoadedPage, setLastLoadedPage] = useState(0)
 
   const [startDate, endDate] = dateRange
+  const includeSettled = false
 
   const pageSizeOptions = useMemo(() => {
     const unique = new Set<number>(PAGE_SIZE_OPTIONS)
@@ -176,6 +177,7 @@ export function LoanPageView({ apiClient = api, initialRange }: LoanPageViewProp
       endDate: toWibIso(endDate),
       page: targetPage,
       pageSize: requestedPageSize,
+      includeSettled,
     }
 
     if (append) {
@@ -192,7 +194,10 @@ export function LoanPageView({ apiClient = api, initialRange }: LoanPageViewProp
         params,
       })
 
-      const mapped: LoanTransaction[] = (data.data || []).map((raw) => ({
+      const filteredRaw = includeSettled
+        ? data.data || []
+        : (data.data || []).filter((raw: any) => raw.status !== 'LN_SETTLE')
+      const mapped: LoanTransaction[] = filteredRaw.map((raw) => ({
         id: raw.id,
         amount: raw.amount ?? 0,
         pendingAmount: raw.pendingAmount ?? 0,

--- a/frontend/src/tests/loan.test.tsx
+++ b/frontend/src/tests/loan.test.tsx
@@ -174,6 +174,7 @@ test('fetches transactions with WIB date parameters', async () => {
   assert.equal(capturedParams.endDate, toWibIso(end))
   assert.equal(capturedParams.page, 1)
   assert.equal(capturedParams.pageSize, DEFAULT_LOAN_PAGE_SIZE)
+  assert.equal(capturedParams.includeSettled, false)
 })
 
 test('submits selected transactions to settle API', async () => {
@@ -208,19 +209,8 @@ test('submits selected transactions to settle API', async () => {
       }
       return {
         data: {
-          data: [
-            {
-              id: 'order-1',
-              amount: 10000,
-              pendingAmount: 0,
-              status: 'LN_SETTLE',
-              createdAt: new Date('2024-01-02T03:00:00Z').toISOString(),
-              loanedAt: new Date('2024-01-03T02:00:00Z').toISOString(),
-              loanAmount: 5000,
-              loanCreatedAt: new Date('2024-01-03T02:00:00Z').toISOString(),
-            },
-          ],
-          meta: { total: 1, page: 1, pageSize: DEFAULT_LOAN_PAGE_SIZE },
+          data: [],
+          meta: { total: 0, page: 1, pageSize: DEFAULT_LOAN_PAGE_SIZE },
         },
       }
     }
@@ -292,18 +282,8 @@ test('bulk settle submits every selectable order id', async () => {
               loanAmount: null,
               loanCreatedAt: null,
             },
-            {
-              id: 'order-3',
-              amount: 15000,
-              pendingAmount: 0,
-              status: 'LN_SETTLE',
-              createdAt: new Date('2024-01-02T05:00:00Z').toISOString(),
-              loanedAt: new Date('2024-01-02T06:00:00Z').toISOString(),
-              loanAmount: 15000,
-              loanCreatedAt: new Date('2024-01-02T06:00:00Z').toISOString(),
-            },
           ],
-          meta: { total: 3, page: 1, pageSize: DEFAULT_LOAN_PAGE_SIZE },
+          meta: { total: 2, page: 1, pageSize: DEFAULT_LOAN_PAGE_SIZE },
         },
       }
     }
@@ -379,7 +359,7 @@ test('allows loading additional loan transaction pages', async () => {
               id: 'order-2',
               amount: 20000,
               pendingAmount: 0,
-              status: 'LN_SETTLE',
+              status: 'PAID',
               createdAt: new Date('2024-01-02T05:00:00Z').toISOString(),
               loanedAt: new Date('2024-01-02T06:00:00Z').toISOString(),
               loanAmount: 20000,


### PR DESCRIPTION
## Summary
- limit admin loan transaction queries to PAID orders by default while allowing an includeSettled opt-in
- update backend and frontend tests to reflect the narrower dataset and cover the opt-in path
- ensure the admin loan UI requests only active PAID transactions and filters out settled rows by default

## Testing
- node --test -r ts-node/register test/adminLoan.routes.test.ts
- npx --yes tsx --tsconfig frontend/tsconfig.json --test frontend/src/tests/loan.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68da347818b08328bde4539627df5f8c