### PR TITLE
Fix admin loan status filter typing

### DIFF
--- a/src/controller/admin/loan.controller.ts
+++ b/src/controller/admin/loan.controller.ts
@@ -55,12 +55,10 @@ export async function getLoanTransactions(req: AuthRequest, res: Response) {
 
     const safePageSize = Math.min(pageSize, MAX_PAGE_SIZE);
     const skip = (page - 1) * safePageSize;
-    const statusFilter = includeSettled
-      ? { in: ['PAID', 'LN_SETTLE'] as const }
-      : { in: ['PAID'] as const };
+    const statusValues = includeSettled ? ['PAID', 'LN_SETTLE'] : ['PAID'];
     const where = {
       subMerchantId,
-      status: statusFilter,
+      status: { in: statusValues },
       createdAt: {
         gte: start,
         lte: end,


### PR DESCRIPTION
## Summary
- rebuild the admin loan status filter to use a mutable array before applying it to the Prisma query

## Testing
- node --test -r ts-node/register test/adminLoan.routes.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68da383aa94083289ab15b06a9ba6ee2