### PR TITLE
Add loan-settled handling across backend and dashboards

### DIFF
--- a/frontend/src/components/dashboard/TransactionsTable.tsx
+++ b/frontend/src/components/dashboard/TransactionsTable.tsx
@@ -84,21 +84,26 @@ export default function TransactionsTable({
 
   const statusBadge = (s?: string) => {
     const v = (s || '').toUpperCase()
-    const map: Record<string, { className: string; label?: string }> = {
+    const map: Record<string, { className: string; label?: string; title?: string }> = {
       SUCCESS: { className: 'bg-emerald-950/40 text-emerald-300 border-emerald-900/40' },
       PAID: { className: 'bg-indigo-950/40 text-indigo-300 border-indigo-900/40' },
       PENDING: { className: 'bg-amber-950/40 text-amber-300 border-amber-900/40' },
       EXPIRED: { className: 'bg-neutral-900/60 text-neutral-300 border-neutral-800' },
       DONE: { className: 'bg-sky-950/40 text-sky-300 border-sky-900/40' },
       FAILED: { className: 'bg-rose-950/40 text-rose-300 border-rose-900/40' },
-      LN_SETTLE: {
+      LN_SETTLED: {
         className: 'bg-purple-950/40 text-purple-200 border-purple-900/40',
         label: 'LOAN SETTLED',
+        title:
+          'Loan-settled: transaksi ditandai sebagai pelunasan pinjaman/manual, tidak ikut proses settlement.',
       },
     }
     const meta = map[v] ?? map.EXPIRED
     return (
-      <span className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium ${meta.className}`}>
+      <span
+        title={meta.title}
+        className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium ${meta.className}`}
+      >
         {meta.label ?? (v || '-')}
       </span>
     )
@@ -189,7 +194,7 @@ export default function TransactionsTable({
               <option value="PAID">PAID</option>
               <option value="PENDING">PENDING</option>
               <option value="EXPIRED">EXPIRED</option>
-              <option value="LN_SETTLE">LN_SETTLE</option>
+              <option value="LN_SETTLED">LN_SETTLED</option>
             </select>
           </div>
 
@@ -341,7 +346,7 @@ export default function TransactionsTable({
                           <span>
                             {t.netSettle.toLocaleString('id-ID', { style: 'currency', currency: 'IDR' })}
                           </span>
-                          {t.status === 'LN_SETTLE' && (
+                          {t.status === 'LN_SETTLED' && (
                             <span className="text-[11px] font-normal uppercase tracking-wide text-purple-200/80">
                               Loan Amount
                             </span>

--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -458,7 +458,7 @@ export default function DashboardPage() {
       setTotalPages(Math.max(1, Math.ceil(data.total / perPage)))
       setTotalTrans(data.totalPaid)
 
-      const VALID_STATUSES: Tx['status'][] = ['SUCCESS', 'PENDING', 'EXPIRED', 'DONE', 'PAID', 'LN_SETTLE']
+      const VALID_STATUSES: Tx['status'][] = ['SUCCESS', 'PENDING', 'EXPIRED', 'DONE', 'PAID', 'LN_SETTLED']
 
       const mapped: Tx[] = data.transactions.map(o => {
         const raw = o.status ?? ''

--- a/frontend/src/types/dashboard.ts
+++ b/frontend/src/types/dashboard.ts
@@ -7,7 +7,7 @@ export type Tx = {
   feeLauncx: number
   feePg: number
   netSettle: number
-  status: '' | 'SUCCESS' | 'PENDING' | 'EXPIRED' | 'DONE' | 'PAID' | 'LN_SETTLE'
+  status: '' | 'SUCCESS' | 'PENDING' | 'EXPIRED' | 'DONE' | 'PAID' | 'LN_SETTLED'
   settlementStatus: string
   channel: string
   paymentReceivedTime?: string

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -229,6 +229,7 @@ model Order {
   pgRefId          String?
   pgClientRef      String?
   providerPayload  Json?
+  metadata         Json?
   paymentReceivedTime  DateTime?      // full.payment_received_time
   settlementTime       DateTime?      // full.settlement_time
   trxExpirationTime    DateTime?      // full.trx_expiration_time

--- a/src/route/admin/merchant.routes.ts
+++ b/src/route/admin/merchant.routes.ts
@@ -48,7 +48,7 @@ router.get('/dashboard/profit',       ctrl.getPlatformProfit)
 router.get('/dashboard/profit-submerchant', ctrl.getProfitPerSubMerchant)
 
 router.get('/loan/transactions', loanCtrl.getLoanTransactions)
-router.post('/loan/settle', loanCtrl.settleLoanOrders)
+router.post('/loan/mark-settled', loanCtrl.markLoanOrdersSettled)
 
 router.get('/dashboard/withdrawals',  ctrl.getDashboardWithdrawals)
 router.patch(

--- a/src/types/orderStatus.ts
+++ b/src/types/orderStatus.ts
@@ -1,0 +1,19 @@
+export const ORDER_STATUS = {
+  PENDING: 'PENDING',
+  PROCESSING: 'PROCESSING',
+  PAID: 'PAID',
+  LN_SETTLED: 'LN_SETTLED',
+  SUCCESS: 'SUCCESS',
+  DONE: 'DONE',
+  SETTLED: 'SETTLED',
+  FAILED: 'FAILED',
+  EXPIRED: 'EXPIRED',
+  CANCELLED: 'CANCELLED',
+  COMPLETED: 'COMPLETED',
+  REFUNDED: 'REFUNDED',
+  TEST: 'TEST',
+} as const;
+
+export type OrderStatus = (typeof ORDER_STATUS)[keyof typeof ORDER_STATUS];
+
+export const LOAN_SETTLED_METADATA_REASON = 'loan_adjustment';

--- a/src/util/orderEvents.ts
+++ b/src/util/orderEvents.ts
@@ -1,0 +1,43 @@
+import { EventEmitter } from 'node:events';
+
+type OrderLoanSettledEvent = {
+  orderId: string;
+  previousStatus: string;
+  adminId?: string;
+  markedAt: string;
+  note?: string;
+};
+
+type OrderEventPayloads = {
+  'order.loan_settled': OrderLoanSettledEvent;
+};
+
+const emitter = new EventEmitter();
+
+export function emitOrderEvent<K extends keyof OrderEventPayloads>(
+  event: K,
+  payload: OrderEventPayloads[K],
+) {
+  emitter.emit(event, payload);
+}
+
+export function onOrderEvent<K extends keyof OrderEventPayloads>(
+  event: K,
+  listener: (payload: OrderEventPayloads[K]) => void,
+) {
+  emitter.on(event, listener);
+}
+
+export function onceOrderEvent<K extends keyof OrderEventPayloads>(
+  event: K,
+  listener: (payload: OrderEventPayloads[K]) => void,
+) {
+  emitter.once(event, listener);
+}
+
+export function removeOrderEventListener<K extends keyof OrderEventPayloads>(
+  event: K,
+  listener: (payload: OrderEventPayloads[K]) => void,
+) {
+  emitter.off(event, listener);
+}


### PR DESCRIPTION
## Summary
- add the LN_SETTLED order status, metadata helpers, and event utilities to support loan settlement adjustments
- expose /admin/merchants/loan/mark-settled for admins and update dashboard/client aggregations to ignore LN_SETTLED in settlement totals
- refresh admin loan management UI, badges, and tests so optional notes persist through the API call and LN_SETTLED displays consistently

## Testing
- node --test -r ts-node/register test/adminLoan.routes.test.ts
- npx tsx --test src/tests/loan.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68da4919685c83288aed68e47f3a53e6