### PR TITLE
Use relative admin endpoints for settlement adjust

### DIFF
--- a/frontend/src/pages/admin/settlement-adjust.tsx
+++ b/frontend/src/pages/admin/settlement-adjust.tsx
@@ -178,7 +178,7 @@ export default function SettlementAdjustPage() {
       params.to = toWibEnd(end).toISOString()
 
       try {
-        const { data } = await api.get<any>('/api/v1/admin/orders', { params })
+        const { data } = await api.get<any>('/admin/orders', { params })
         const listSource = Array.isArray(data?.data)
           ? data.data
           : Array.isArray(data?.orders)
@@ -295,7 +295,7 @@ export default function SettlementAdjustPage() {
       if (reason.trim()) payload.reason = reason.trim()
 
       const { data } = await api.post<ReversalResponse>(
-        '/api/v1/admin/settlement/reverse-to-ln-settle',
+        '/admin/settlement/reverse-to-ln-settle',
         payload
       )
 


### PR DESCRIPTION
## Summary
- update the settlement orders fetch to use the same relative admin path as other calls on the page
- align the reversal submission with the relative admin endpoint used elsewhere

## Testing
- npm run lint *(fails: command prompts for ESLint reconfiguration in non-interactive environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da662f9ab48328a0a01b3d099dd45e