### PR TITLE
Add reversal endpoint for settlement adjustments

### DIFF
--- a/src/route/admin/settlement.routes.ts
+++ b/src/route/admin/settlement.routes.ts
@@ -5,7 +5,10 @@ import {
   startSettlement,
   settlementStatus,
 } from '../../controller/admin/settlement.controller'
-import { adjustSettlements } from '../../controller/admin/settlementAdjustment.controller'
+import {
+  adjustSettlements,
+  reverseSettlementToLnSettle,
+} from '../../controller/admin/settlementAdjustment.controller'
 
 const router = Router()
 
@@ -15,6 +18,7 @@ router.post('/', manualSettlement)
 router.post('/start', startSettlement)
 router.get('/status/:jobId', settlementStatus)
 router.post('/adjust', adjustSettlements)
+router.post('/reverse-to-ln-settle', reverseSettlementToLnSettle)
 
 export default router
 


### PR DESCRIPTION
## Summary
- add a reverseSettlementToLnSettle handler to clear settlement fields, restore LN_SETTLE status, and log reversal metadata
- expose POST /admin/settlement/reverse-to-ln-settle on the admin settlement router for the frontend bulk action

## Testing
- npm run build *(fails: existing TypeScript errors about missing Prisma enums)*

------
https://chatgpt.com/codex/tasks/task_e_68da6a35f4f08328a864420328cb3344