### PR TITLE
Increase settlement admin page size

### DIFF
--- a/frontend/src/pages/admin/settlement-adjust.tsx
+++ b/frontend/src/pages/admin/settlement-adjust.tsx
@@ -120,7 +120,7 @@ export default function SettlementAdjustPage() {
   const [rowsError, setRowsError] = useState('')
 
   const [page, setPage] = useState(1)
-  const [pageSize] = useState(25)
+  const [pageSize] = useState(1500)
   const [totalCount, setTotalCount] = useState(0)
 
   const [selectedIds, setSelectedIds] = useState<string[]>([])
@@ -624,7 +624,7 @@ export default function SettlementAdjustPage() {
 
           <div className="flex items-center justify-between text-xs text-neutral-500">
             <div>
-              Halaman {page} dari {totalPages}
+              Halaman {page} dari {totalPages} (maks {pageSize.toLocaleString('id-ID')} order/halaman)
             </div>
             <div className="flex items-center gap-2">
               <button


### PR DESCRIPTION
## Summary
- increase the settlement adjustment page size to 1500 to request more eligible rows per page
- update the pagination footer message to mention the maximum rows per page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da7d38e1f48328b071f72399787dba