### PR TITLE
Optimize settlement sub-merchant lookup

### DIFF
--- a/frontend/src/pages/admin/settlement-adjust.tsx
+++ b/frontend/src/pages/admin/settlement-adjust.tsx
@@ -113,6 +113,10 @@ export default function SettlementAdjustPage() {
   const [debouncedSearch, setDebouncedSearch] = useState('')
 
   const [subMerchants, setSubMerchants] = useState<SubMerchantOption[]>([])
+  const subMerchantNameMap = useMemo(
+    () => Object.fromEntries(subMerchants.map(sub => [sub.id, sub.name ?? null])),
+    [subMerchants]
+  )
   const [loadingSubs, setLoadingSubs] = useState(false)
   const [subsError, setSubsError] = useState('')
 
@@ -240,7 +244,7 @@ export default function SettlementAdjustPage() {
           mapped.push({
             id,
             subMerchantId,
-            subMerchantName: subMerchants.find(sub => sub.id === subMerchantId)?.name ?? null,
+            subMerchantName: subMerchantNameMap[subMerchantId] ?? null,
             status: String(raw?.status ?? ''),
             settlementTime: settlementTime.toISOString(),
             settlementAmount: settlementAmount != null ? Number(settlementAmount) : null,
@@ -268,7 +272,7 @@ export default function SettlementAdjustPage() {
         }
       }
     },
-    [dateRange, debouncedSearch, pageSize, selectedSubMerchant, subMerchants]
+    [dateRange, debouncedSearch, pageSize, selectedSubMerchant, subMerchantNameMap]
   )
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- memoize a map of sub-merchant names keyed by id for settlement adjustment rows
- use the memoized map when building settlement rows and update hook dependencies accordingly

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68da89f955b48328a81f8b4b647854cd