### PR TITLE
Add admin loan settlement by range endpoint

### DIFF
--- a/docs/services/admin.md
+++ b/docs/services/admin.md
@@ -8,7 +8,8 @@ Administrative endpoints require an authenticated admin account.
 - `GET /api/v1/admin/ip-whitelist/global` – retrieve IPs allowed to access any API route.
 - `PUT /api/v1/admin/ip-whitelist/global` – update the global whitelist with the same `{ "ips": ["1.1.1.1"] }` payload. Requires a super admin token.
 - `GET /api/v1/admin/merchants/loan/transactions` – fetch loan transactions filtered by `subMerchantId`, `startDate`, and `endDate`. Supports pagination via `page` (default `1`) and `pageSize` (default `50`, maximum `100`). The response includes a `meta` object `{ "total", "page", "pageSize" }` for UI pagination.
-- `POST /api/v1/admin/merchants/loan/settle` – settle pending loan transactions by submitting `{ "subMerchantId", "orderIds": [] }`.
+- `POST /api/v1/admin/merchants/loan/mark-settled` – settle pending loan transactions by submitting `{ "orderIds": [] }` (optional `note` field adds an audit trail entry).
+- `POST /api/v1/admin/merchants/loan/mark-settled/by-range` – settle **all** PAID loan transactions for a `subMerchantId` within `{ "startDate", "endDate" }` (inclusive). The payload supports an optional `note` mirroring the manual endpoint. Orders are processed in server-side batches governed by `LOAN_FETCH_BATCH_SIZE` to avoid timeouts; the response returns the same `{ ok, fail, errors }` summary as the manual endpoint.
 
 ## Reconcile Partner Balances
 - Script: `npm run reconcile-balances` recomputes balances from settled orders and withdrawals.

--- a/src/route/admin/merchant.routes.ts
+++ b/src/route/admin/merchant.routes.ts
@@ -49,6 +49,7 @@ router.get('/dashboard/profit-submerchant', ctrl.getProfitPerSubMerchant)
 
 router.get('/loan/transactions', loanCtrl.getLoanTransactions)
 router.post('/loan/mark-settled', loanCtrl.markLoanOrdersSettled)
+router.post('/loan/mark-settled/by-range', loanCtrl.markLoanOrdersSettledByRange)
 
 router.get('/dashboard/withdrawals',  ctrl.getDashboardWithdrawals)
 router.patch(


### PR DESCRIPTION
## Summary
- extract the reusable loan settlement update helper and shared schemas
- add POST /api/v1/admin/merchants/loan/mark-settled/by-range to batch settle PAID orders
- document the new endpoint and extend admin loan route tests for batched range settlement

## Testing
- node --test -r ts-node/register test/adminLoan.routes.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68daa95f5c188328953f368d348e39fd