### PR TITLE
Add async loan settlement job support

### DIFF
--- a/src/route/admin/merchant.routes.ts
+++ b/src/route/admin/merchant.routes.ts
@@ -50,6 +50,11 @@ router.get('/dashboard/profit-submerchant', ctrl.getProfitPerSubMerchant)
 router.get('/loan/transactions', loanCtrl.getLoanTransactions)
 router.post('/loan/mark-settled', loanCtrl.markLoanOrdersSettled)
 router.post('/loan/mark-settled/by-range', loanCtrl.markLoanOrdersSettledByRange)
+router.post('/loan/mark-settled/by-range/start', loanCtrl.startLoanSettlementJob)
+router.get(
+  '/loan/mark-settled/by-range/status/:jobId',
+  loanCtrl.loanSettlementJobStatus,
+)
 
 router.get('/dashboard/withdrawals',  ctrl.getDashboardWithdrawals)
 router.patch(

--- a/src/service/loanSettlement.ts
+++ b/src/service/loanSettlement.ts
@@ -1,0 +1,300 @@
+import moment from 'moment-timezone'
+
+import { prisma } from '../core/prisma'
+import { ORDER_STATUS, LOAN_SETTLED_METADATA_REASON } from '../types/orderStatus'
+import { logAdminAction } from '../util/adminLog'
+import { emitOrderEvent } from '../util/orderEvents'
+import { wibTimestamp } from '../util/time'
+
+const DEFAULT_LOAN_CHUNK_SIZE = 25
+const configuredLoanChunkSize = Number(process.env.LOAN_CREATE_MANY_CHUNK_SIZE)
+const LOAN_CREATE_MANY_CHUNK_SIZE =
+  Number.isFinite(configuredLoanChunkSize) && configuredLoanChunkSize >= 1
+    ? Math.floor(configuredLoanChunkSize)
+    : DEFAULT_LOAN_CHUNK_SIZE
+
+const DEFAULT_LOAN_FETCH_BATCH_SIZE = 100
+const configuredLoanFetchBatchSize = Number(process.env.LOAN_FETCH_BATCH_SIZE)
+const LOAN_FETCH_BATCH_SIZE =
+  Number.isFinite(configuredLoanFetchBatchSize) && configuredLoanFetchBatchSize >= 1
+    ? Math.floor(configuredLoanFetchBatchSize)
+    : DEFAULT_LOAN_FETCH_BATCH_SIZE
+
+export const toStartOfDayWib = (value: string) => {
+  const date = moment.tz(value, 'Asia/Jakarta')
+  if (!date.isValid()) {
+    throw new Error('Invalid startDate')
+  }
+  return date.startOf('day').toDate()
+}
+
+export const toEndOfDayWib = (value: string) => {
+  const date = moment.tz(value, 'Asia/Jakarta')
+  if (!date.isValid()) {
+    throw new Error('Invalid endDate')
+  }
+  return date.endOf('day').toDate()
+}
+
+export type MarkSettledSummary = {
+  ok: string[]
+  fail: string[]
+  errors: { orderId: string; message: string }[]
+}
+
+export type LoanSettlementEventPayload = {
+  orderId: string
+  previousStatus: string
+  adminId?: string
+  markedAt: string
+  note?: string
+}
+
+export type OrderForLoanSettlement = {
+  id: string
+  status: string
+  pendingAmount: number | null | undefined
+  settlementAmount: number | null | undefined
+  settlementStatus: string | null | undefined
+  metadata: unknown
+  subMerchantId: string | null | undefined
+  loanedAt: Date | null
+}
+
+export type LoanSettlementUpdate = {
+  id: string
+  subMerchantId?: string | null
+  metadata: Record<string, any>
+  pendingAmount: number | null | undefined
+}
+
+export function normalizeMetadata(value: unknown): Record<string, any> {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    return { ...(value as Record<string, any>) }
+  }
+  return {}
+}
+
+export async function applyLoanSettlementUpdates({
+  updates,
+  summary,
+  adminId,
+  note,
+  now,
+  markedAtIso,
+}: {
+  updates: LoanSettlementUpdate[]
+  summary: MarkSettledSummary
+  adminId?: string
+  note?: string
+  now: Date
+  markedAtIso: string
+}): Promise<LoanSettlementEventPayload[]> {
+  if (updates.length === 0) {
+    return []
+  }
+
+  const configuredTimeout = Number(process.env.LOAN_TRANSACTION_TIMEOUT)
+  const transactionTimeout =
+    Number.isFinite(configuredTimeout) && configuredTimeout > 0 ? configuredTimeout : 20000
+
+  const events: LoanSettlementEventPayload[] = []
+  const chunkSize = Math.max(1, LOAN_CREATE_MANY_CHUNK_SIZE)
+
+  for (let start = 0; start < updates.length; start += chunkSize) {
+    const chunk = updates.slice(start, start + chunkSize)
+
+    await prisma.$transaction(
+      async tx => {
+        for (const update of chunk) {
+          try {
+            const result = await tx.order.updateMany({
+              where: { id: update.id, status: ORDER_STATUS.PAID },
+              data: {
+                status: ORDER_STATUS.LN_SETTLED,
+                pendingAmount: null,
+                settlementStatus: null,
+                loanedAt: now,
+                metadata: update.metadata,
+              },
+            })
+
+            if (result.count === 0) {
+              if (!summary.fail.includes(update.id)) {
+                summary.fail.push(update.id)
+              }
+              summary.errors.push({
+                orderId: update.id,
+                message: 'Order status changed before loan settlement could be applied',
+              })
+              continue
+            }
+
+            if (!summary.ok.includes(update.id)) {
+              summary.ok.push(update.id)
+            }
+
+            const amount = Number(update.pendingAmount ?? 0)
+            if (amount > 0 && update.subMerchantId) {
+              await tx.loanEntry.upsert({
+                where: { orderId: update.id },
+                create: {
+                  orderId: update.id,
+                  subMerchantId: update.subMerchantId,
+                  amount,
+                  metadata: {
+                    reason: LOAN_SETTLED_METADATA_REASON,
+                    markedAt: markedAtIso,
+                    ...(adminId ? { markedBy: adminId } : {}),
+                    ...(note ? { note } : {}),
+                  },
+                },
+                update: {
+                  amount,
+                  metadata: {
+                    reason: LOAN_SETTLED_METADATA_REASON,
+                    markedAt: markedAtIso,
+                    ...(adminId ? { markedBy: adminId } : {}),
+                    ...(note ? { note } : {}),
+                  },
+                },
+              })
+            }
+
+            events.push({
+              orderId: update.id,
+              previousStatus: ORDER_STATUS.PAID,
+              adminId,
+              markedAt: markedAtIso,
+              note,
+            })
+          } catch (error: any) {
+            if (!summary.fail.includes(update.id)) {
+              summary.fail.push(update.id)
+            }
+            const message =
+              error instanceof Error && error.message
+                ? error.message
+                : 'Failed to mark order as loan-settled'
+            summary.errors.push({ orderId: update.id, message })
+          }
+        }
+      },
+      { timeout: transactionTimeout },
+    )
+  }
+
+  return events
+}
+
+export async function runLoanSettlementByRange({
+  subMerchantId,
+  startDate,
+  endDate,
+  note,
+  adminId,
+}: {
+  subMerchantId: string
+  startDate: string
+  endDate: string
+  note?: string
+  adminId?: string
+}): Promise<MarkSettledSummary> {
+  const trimmedNote = note?.trim() ? note.trim() : undefined
+  const start = toStartOfDayWib(startDate)
+  const end = toEndOfDayWib(endDate)
+
+  const summary: MarkSettledSummary = { ok: [], fail: [], errors: [] }
+  const now = wibTimestamp()
+  const markedAtIso = now.toISOString()
+  const batchSize = Math.max(1, LOAN_FETCH_BATCH_SIZE)
+
+  const allOrderIds: string[] = []
+
+  let page = 0
+  while (true) {
+    const orders = (await prisma.order.findMany({
+      where: {
+        subMerchantId,
+        status: ORDER_STATUS.PAID,
+        createdAt: {
+          gte: start,
+          lte: end,
+        },
+      },
+      orderBy: { createdAt: 'asc' },
+      select: {
+        id: true,
+        status: true,
+        pendingAmount: true,
+        settlementAmount: true,
+        settlementStatus: true,
+        metadata: true,
+        subMerchantId: true,
+        loanedAt: true,
+      },
+      take: batchSize,
+      skip: page * batchSize,
+    })) as OrderForLoanSettlement[]
+
+    if (orders.length === 0) {
+      break
+    }
+
+    const updates: LoanSettlementUpdate[] = []
+    for (const order of orders) {
+      allOrderIds.push(order.id)
+
+      const metadata = normalizeMetadata(order.metadata)
+      const auditEntry = {
+        reason: LOAN_SETTLED_METADATA_REASON,
+        previousStatus: ORDER_STATUS.PAID,
+        markedBy: adminId ?? 'unknown',
+        markedAt: markedAtIso,
+        ...(trimmedNote ? { note: trimmedNote } : {}),
+      }
+
+      const historyKey = 'loanSettlementHistory'
+      const history = Array.isArray(metadata[historyKey])
+        ? [...metadata[historyKey], auditEntry]
+        : [auditEntry]
+
+      metadata[historyKey] = history
+      metadata.lastLoanSettlement = auditEntry
+
+      updates.push({
+        id: order.id,
+        subMerchantId: order.subMerchantId,
+        metadata,
+        pendingAmount: order.pendingAmount,
+      })
+    }
+
+    const events = await applyLoanSettlementUpdates({
+      updates,
+      summary,
+      adminId,
+      note: trimmedNote,
+      now,
+      markedAtIso,
+    })
+
+    for (const event of events) {
+      emitOrderEvent('order.loan_settled', event)
+    }
+
+    page += 1
+  }
+
+  if (adminId && allOrderIds.length > 0) {
+    await logAdminAction(adminId, 'loanMarkSettled', undefined, {
+      orderIds: allOrderIds,
+      ok: summary.ok,
+      fail: summary.fail,
+      note: trimmedNote,
+    })
+  }
+
+  return summary
+}
+

--- a/src/worker/loanSettlementJob.ts
+++ b/src/worker/loanSettlementJob.ts
@@ -1,0 +1,83 @@
+import { v4 as uuidv4 } from 'uuid'
+
+import {
+  runLoanSettlementByRange,
+  type MarkSettledSummary,
+} from '../service/loanSettlement'
+import { wibTimestamp } from '../util/time'
+
+export type LoanSettlementJobStatus = 'queued' | 'running' | 'completed' | 'failed'
+
+export interface LoanSettlementJobPayload {
+  subMerchantId: string
+  startDate: string
+  endDate: string
+  note?: string
+  adminId?: string
+}
+
+export interface LoanSettlementJob {
+  id: string
+  status: LoanSettlementJobStatus
+  payload: LoanSettlementJobPayload
+  summary: MarkSettledSummary
+  error?: string
+  createdAt: string
+  updatedAt: string
+  startedAt?: string
+  completedAt?: string
+}
+
+const jobs = new Map<string, LoanSettlementJob>()
+const queue: LoanSettlementJob[] = []
+let current: LoanSettlementJob | null = null
+
+const getNowIso = () => wibTimestamp().toISOString()
+
+function runNext() {
+  if (current || queue.length === 0) return
+
+  const job = queue.shift()!
+  current = job
+  job.status = 'running'
+  job.startedAt = getNowIso()
+  job.updatedAt = job.startedAt
+
+  runLoanSettlementByRange(job.payload)
+    .then(summary => {
+      job.summary = summary
+      job.status = 'completed'
+      job.completedAt = getNowIso()
+      job.updatedAt = job.completedAt
+    })
+    .catch(error => {
+      job.status = 'failed'
+      job.error = error instanceof Error ? error.message : String(error)
+      job.updatedAt = getNowIso()
+    })
+    .finally(() => {
+      current = null
+      runNext()
+    })
+}
+
+export function startLoanSettlementJob(payload: LoanSettlementJobPayload) {
+  const nowIso = getNowIso()
+  const job: LoanSettlementJob = {
+    id: uuidv4(),
+    status: 'queued',
+    payload: { ...payload },
+    summary: { ok: [], fail: [], errors: [] },
+    createdAt: nowIso,
+    updatedAt: nowIso,
+  }
+
+  jobs.set(job.id, job)
+  queue.push(job)
+  runNext()
+  return job.id
+}
+
+export function getLoanSettlementJob(jobId: string) {
+  return jobs.get(jobId)
+}


### PR DESCRIPTION
## Summary
- extract the range-based loan settlement workflow into `runLoanSettlementByRange` and reuse it from controllers and background jobs
- add an in-memory loan settlement worker with start/status endpoints wired through the admin routes
- update the admin loan management UI to launch and monitor background settlements with accompanying test coverage

## Testing
- `node --test -r ts-node/register test/adminLoan.routes.test.ts`
- `npx tsx --test src/tests/loan.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68dab09ed9d883288d5efb7fdadf9d2b