### PR TITLE
Add settlement adjustment job service and worker

### DIFF
--- a/src/route/admin/settlement.routes.ts
+++ b/src/route/admin/settlement.routes.ts
@@ -9,6 +9,8 @@ import {
   adjustSettlements,
   getEligibleSettlements,
   reverseSettlementToLnSettle,
+  settlementAdjustmentStatus,
+  startSettlementAdjustmentJob,
 } from '../../controller/admin/settlementAdjustment.controller'
 
 const router = Router()
@@ -19,6 +21,8 @@ router.post('/', manualSettlement)
 router.post('/start', startSettlement)
 router.get('/status/:jobId', settlementStatus)
 router.post('/adjust', adjustSettlements)
+router.post('/adjust/job', startSettlementAdjustmentJob)
+router.get('/adjust/job/:jobId', settlementAdjustmentStatus)
 router.get('/eligible', getEligibleSettlements)
 router.post('/reverse-to-ln-settle', reverseSettlementToLnSettle)
 

--- a/src/service/settlementAdjustmentJob.ts
+++ b/src/service/settlementAdjustmentJob.ts
@@ -1,0 +1,293 @@
+import moment from 'moment-timezone'
+import { prisma } from '../core/prisma'
+import { computeSettlement } from './feeSettlement'
+
+type FeeConfig = number | Record<string, number>
+
+const JAKARTA_TZ = 'Asia/Jakarta'
+
+const prismaTxTimeoutMs = (() => {
+  const rawTimeout = process.env.PRISMA_TX_TIMEOUT_MS
+  if (rawTimeout == null || rawTimeout === '') {
+    return undefined
+  }
+
+  const parsedTimeout = Number(rawTimeout)
+  if (!Number.isFinite(parsedTimeout) || parsedTimeout <= 0) {
+    console.warn('[settlementAdjustment] Ignoring invalid PRISMA_TX_TIMEOUT_MS value', {
+      rawTimeout,
+    })
+    return undefined
+  }
+
+  return parsedTimeout
+})()
+
+const prismaTxOptions = prismaTxTimeoutMs ? { timeout: prismaTxTimeoutMs } : undefined
+
+export interface SettlementAdjustmentJobParams {
+  subMerchantId: string
+  settlementStatus: string
+  start: string | Date
+  end: string | Date
+  feeConfig?: FeeConfig
+  settlementTime?: string | Date | null
+}
+
+export interface SettlementAdjustmentProgress {
+  processed: number
+  total: number
+}
+
+export interface SettlementAdjustmentSummary {
+  totalOrders: number
+  totalTransactions: number
+  updatedOrderIds: string[]
+  updatedTransactionIds: string[]
+  startBoundary: Date
+  endBoundary: Date
+}
+
+export interface SettlementAdjustmentResult {
+  updatedOrderIds: string[]
+  updatedTransactionIds: string[]
+}
+
+type OrderRecord = {
+  id: string
+  subMerchantId: string | null
+  amount: number
+  fee3rdParty: number | null
+  feeLauncx: number | null
+}
+
+type TransactionRecord = {
+  id: string
+  subMerchantId: string | null
+  amount: number | null
+  settlementAmount: number | null
+}
+
+type AdjustmentRecord =
+  | { type: 'order'; data: OrderRecord }
+  | { type: 'transaction'; data: TransactionRecord }
+
+type RunOptions = {
+  onProgress?: (progress: SettlementAdjustmentProgress) => void
+}
+
+type AdjustmentContext = {
+  settlementStatus: string
+  settlementTime?: string | Date | null
+  feeConfig?: FeeConfig
+  targetSubMerchantId?: string
+}
+
+function resolveBoundary(value: string | Date, boundary: 'start' | 'end') {
+  const m = moment.tz(value, JAKARTA_TZ)
+  if (!m.isValid()) {
+    throw new Error(`Invalid date provided for ${boundary}`)
+  }
+  return boundary === 'start' ? m.startOf('day').toDate() : m.endOf('day').toDate()
+}
+
+function resolveFeePercent(
+  feeConfig: FeeConfig | undefined,
+  id: string,
+  fallbackFee?: number | null,
+  baseAmount?: number
+) {
+  if (typeof feeConfig === 'number') {
+    return feeConfig
+  }
+  if (feeConfig && typeof feeConfig === 'object') {
+    const val = feeConfig[id]
+    if (typeof val === 'number') {
+      return val
+    }
+  }
+  if (fallbackFee != null && baseAmount) {
+    const pct = (fallbackFee / baseAmount) * 100
+    return Number.isFinite(pct) ? pct : 0
+  }
+  return 0
+}
+
+async function applyBatchAdjustments(
+  records: AdjustmentRecord[],
+  context: AdjustmentContext,
+  options: RunOptions,
+  total: number
+): Promise<SettlementAdjustmentResult> {
+  const updates: { id: string; type: AdjustmentRecord['type'] }[] = []
+  const settlementDate = context.settlementTime ? new Date(context.settlementTime) : null
+  const isFinalSettlement = ['SETTLED', 'DONE', 'SUCCESS', 'COMPLETED'].includes(context.settlementStatus)
+  const notifyProgress = (() => {
+    let processed = 0
+    return () => {
+      processed += 1
+      if (total > 0) {
+        options.onProgress?.({ processed, total })
+      }
+    }
+  })()
+
+  const batchSize = 200
+  for (let i = 0; i < records.length; i += batchSize) {
+    const batch = records.slice(i, i + batchSize)
+    const batchUpdates = await prisma.$transaction(async tx => {
+      const localUpdates: { id: string; type: AdjustmentRecord['type'] }[] = []
+      for (const record of batch) {
+        if (record.type === 'order') {
+          const order = record.data
+          const baseAmount = Number(order.amount ?? 0) - Number(order.fee3rdParty ?? 0)
+          const feePercent = resolveFeePercent(context.feeConfig, order.id, order.feeLauncx, baseAmount)
+          const { fee, settlement } = computeSettlement(baseAmount, { percent: feePercent })
+          const where: Record<string, unknown> = {
+            id: order.id,
+            status: 'PAID',
+          }
+          if (context.targetSubMerchantId) {
+            where.subMerchantId = context.targetSubMerchantId
+          } else if (order.subMerchantId) {
+            where.subMerchantId = order.subMerchantId
+          }
+
+          const result = await tx.order.updateMany({
+            where,
+            data: {
+              settlementStatus: context.settlementStatus,
+              ...(settlementDate ? { settlementTime: settlementDate } : {}),
+              feeLauncx: fee,
+              settlementAmount: settlement,
+            },
+          })
+
+          if (result.count > 0) {
+            if (isFinalSettlement) {
+              const settleWhere: Record<string, unknown> = { id: order.id }
+              if (context.targetSubMerchantId) {
+                settleWhere.subMerchantId = context.targetSubMerchantId
+              } else if (order.subMerchantId) {
+                settleWhere.subMerchantId = order.subMerchantId
+              }
+              await tx.order.updateMany({
+                where: settleWhere,
+                data: { status: 'SETTLED', pendingAmount: null },
+              })
+            }
+            localUpdates.push({ id: order.id, type: 'order' })
+          }
+        } else {
+          const trx = record.data
+          const baseAmount = trx.settlementAmount ?? trx.amount ?? 0
+          const feePercent = resolveFeePercent(context.feeConfig, trx.id)
+          const { settlement } = computeSettlement(baseAmount, { percent: feePercent })
+          await tx.transaction_request.update({
+            where: { id: trx.id },
+            data: {
+              ...(settlementDate ? { settlementAt: settlementDate } : {}),
+              settlementAmount: settlement,
+            },
+          })
+          localUpdates.push({ id: trx.id, type: 'transaction' })
+        }
+        notifyProgress()
+      }
+      return localUpdates
+    }, prismaTxOptions)
+    updates.push(...batchUpdates)
+  }
+
+  if (total === 0) {
+    options.onProgress?.({ processed: 0, total: 0 })
+  }
+
+  return {
+    updatedOrderIds: updates.filter(u => u.type === 'order').map(u => u.id),
+    updatedTransactionIds: updates.filter(u => u.type === 'transaction').map(u => u.id),
+  }
+}
+
+export async function applySettlementAdjustments(
+  source: { orders: OrderRecord[]; transactions: TransactionRecord[] },
+  context: AdjustmentContext,
+  options: RunOptions = {}
+): Promise<SettlementAdjustmentResult> {
+  const records: AdjustmentRecord[] = [
+    ...source.orders.map(order => ({ type: 'order' as const, data: order })),
+    ...source.transactions.map(transaction => ({ type: 'transaction' as const, data: transaction })),
+  ]
+  return applyBatchAdjustments(records, context, options, records.length)
+}
+
+export async function runSettlementAdjustmentJob(
+  params: SettlementAdjustmentJobParams,
+  options: RunOptions = {}
+): Promise<SettlementAdjustmentSummary> {
+  const { subMerchantId, settlementStatus, feeConfig, settlementTime } = params
+  if (!subMerchantId) {
+    throw new Error('subMerchantId is required')
+  }
+  if (!settlementStatus) {
+    throw new Error('settlementStatus is required')
+  }
+
+  const startBoundary = resolveBoundary(params.start, 'start')
+  const endBoundary = resolveBoundary(params.end, 'end')
+
+  const [orders, transactions] = await Promise.all([
+    prisma.order.findMany({
+      where: {
+        status: 'PAID',
+        subMerchantId,
+        createdAt: {
+          gte: startBoundary,
+          lte: endBoundary,
+        },
+      },
+      select: {
+        id: true,
+        amount: true,
+        fee3rdParty: true,
+        feeLauncx: true,
+        subMerchantId: true,
+      },
+    }),
+    prisma.transaction_request.findMany({
+      where: {
+        status: 'SUCCESS',
+        subMerchantId,
+        createdAt: {
+          gte: startBoundary,
+          lte: endBoundary,
+        },
+      },
+      select: {
+        id: true,
+        amount: true,
+        settlementAmount: true,
+        subMerchantId: true,
+      },
+    }),
+  ])
+
+  const result = await applyBatchAdjustments(
+    [
+      ...orders.map(order => ({ type: 'order' as const, data: order })),
+      ...transactions.map(transaction => ({ type: 'transaction' as const, data: transaction })),
+    ],
+    { settlementStatus, feeConfig, settlementTime, targetSubMerchantId: subMerchantId },
+    options,
+    orders.length + transactions.length
+  )
+
+  return {
+    totalOrders: orders.length,
+    totalTransactions: transactions.length,
+    updatedOrderIds: result.updatedOrderIds,
+    updatedTransactionIds: result.updatedTransactionIds,
+    startBoundary,
+    endBoundary,
+  }
+}

--- a/src/worker/settlementAdjustmentJob.ts
+++ b/src/worker/settlementAdjustmentJob.ts
@@ -1,0 +1,118 @@
+import { v4 as uuidv4 } from 'uuid'
+import {
+  runSettlementAdjustmentJob,
+  type SettlementAdjustmentJobParams,
+  type SettlementAdjustmentSummary,
+  type SettlementAdjustmentProgress,
+} from '../service/settlementAdjustmentJob'
+
+export type SettlementAdjustmentJobStatus = 'queued' | 'running' | 'completed' | 'failed'
+
+export interface SettlementAdjustmentWorkerPayload extends SettlementAdjustmentJobParams {
+  adminId?: string
+}
+
+export interface SettlementAdjustmentWorkerJob {
+  id: string
+  status: SettlementAdjustmentJobStatus
+  payload: SettlementAdjustmentWorkerPayload
+  progress: SettlementAdjustmentProgress
+  totals: {
+    totalOrders: number
+    totalTransactions: number
+    updatedOrders: number
+    updatedTransactions: number
+  }
+  range?: {
+    start: string
+    end: string
+  }
+  errors: string[]
+  error?: string
+  createdAt: string
+  updatedAt: string
+  startedAt?: string
+  completedAt?: string
+}
+
+const jobs = new Map<string, SettlementAdjustmentWorkerJob>()
+const queue: SettlementAdjustmentWorkerJob[] = []
+let current: SettlementAdjustmentWorkerJob | null = null
+
+function nowIso() {
+  return new Date().toISOString()
+}
+
+function handleProgress(job: SettlementAdjustmentWorkerJob, progress: SettlementAdjustmentProgress) {
+  job.progress = progress
+  job.updatedAt = nowIso()
+}
+
+function applySummary(job: SettlementAdjustmentWorkerJob, summary: SettlementAdjustmentSummary) {
+  job.totals = {
+    totalOrders: summary.totalOrders,
+    totalTransactions: summary.totalTransactions,
+    updatedOrders: summary.updatedOrderIds.length,
+    updatedTransactions: summary.updatedTransactionIds.length,
+  }
+  job.range = {
+    start: summary.startBoundary.toISOString(),
+    end: summary.endBoundary.toISOString(),
+  }
+}
+
+function runNext() {
+  if (current || queue.length === 0) {
+    return
+  }
+
+  const job = queue.shift()!
+  current = job
+  job.status = 'running'
+  job.startedAt = nowIso()
+  job.updatedAt = job.startedAt
+
+  const { adminId: _adminId, ...payload } = job.payload
+
+  runSettlementAdjustmentJob(payload, {
+    onProgress: progress => handleProgress(job, progress),
+  })
+    .then(summary => {
+      applySummary(job, summary)
+      job.status = 'completed'
+      job.completedAt = nowIso()
+      job.updatedAt = job.completedAt
+    })
+    .catch(err => {
+      job.status = 'failed'
+      job.error = err instanceof Error ? err.message : String(err)
+      job.errors.push(job.error)
+      job.updatedAt = nowIso()
+    })
+    .finally(() => {
+      current = null
+      runNext()
+    })
+}
+
+export function startSettlementAdjustmentWorker(payload: SettlementAdjustmentWorkerPayload) {
+  const created = nowIso()
+  const job: SettlementAdjustmentWorkerJob = {
+    id: uuidv4(),
+    status: 'queued',
+    payload: { ...payload },
+    progress: { processed: 0, total: 0 },
+    totals: { totalOrders: 0, totalTransactions: 0, updatedOrders: 0, updatedTransactions: 0 },
+    errors: [],
+    createdAt: created,
+    updatedAt: created,
+  }
+  jobs.set(job.id, job)
+  queue.push(job)
+  runNext()
+  return job
+}
+
+export function getSettlementAdjustmentJob(jobId: string) {
+  return jobs.get(jobId)
+}

--- a/test/settlementAdjustmentJob.worker.test.ts
+++ b/test/settlementAdjustmentJob.worker.test.ts
@@ -1,0 +1,136 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import express from 'express'
+import request from 'supertest'
+import moment from 'moment-timezone'
+
+process.env.JWT_SECRET = 'test'
+
+const prismaPath = require.resolve('../src/core/prisma')
+const prismaMock: any = {
+  order: {
+    findMany: async () => [],
+    updateMany: async () => ({ count: 0 }),
+  },
+  transaction_request: {
+    findMany: async () => [],
+    update: async () => ({}),
+  },
+}
+prismaMock.$transaction = async (fn: any) => fn(prismaMock)
+require.cache[prismaPath] = {
+  id: prismaPath,
+  filename: prismaPath,
+  loaded: true,
+  exports: {
+    prisma: prismaMock,
+  },
+} as any
+
+const {
+  startSettlementAdjustmentJob,
+  settlementAdjustmentStatus,
+} = require('../src/controller/admin/settlementAdjustment.controller')
+const {
+  runSettlementAdjustmentJob,
+} = require('../src/service/settlementAdjustmentJob')
+
+const app = express()
+app.use(express.json())
+app.post('/settlement/adjust/job', (req, res) => {
+  ;(req as any).userId = 'admin1'
+  startSettlementAdjustmentJob(req as any, res)
+})
+app.get('/settlement/adjust/job/:jobId', (req, res) => {
+  settlementAdjustmentStatus(req as any, res)
+})
+
+test('job creation enqueues worker and reports completion', async () => {
+  const prisma = require.cache[prismaPath].exports.prisma
+  prisma.order.findMany = async () => [
+    { id: 'o1', amount: 100, fee3rdParty: 0, feeLauncx: 0, subMerchantId: 'sub-1' },
+    { id: 'o2', amount: 200, fee3rdParty: 10, feeLauncx: 5, subMerchantId: 'sub-1' },
+  ]
+  prisma.transaction_request.findMany = async () => []
+  const orderUpdates: any[] = []
+  prisma.order.updateMany = async (args: any) => {
+    orderUpdates.push(args)
+    return { count: 1 }
+  }
+
+  const res = await request(app)
+    .post('/settlement/adjust/job')
+    .send({
+      subMerchantId: 'sub-1',
+      settled_from: '2024-02-10',
+      settled_to: '2024-02-11',
+      settlementStatus: 'SETTLED',
+    })
+
+  assert.equal(res.status, 202)
+  assert.ok(res.body.id)
+  const jobId = res.body.id
+
+  let statusRes
+  for (let attempt = 0; attempt < 10; attempt++) {
+    statusRes = await request(app).get(`/settlement/adjust/job/${jobId}`)
+    if (statusRes.body.status === 'completed') break
+    await new Promise(resolve => setTimeout(resolve, 10))
+  }
+
+  assert.equal(statusRes!.status, 200)
+  assert.equal(statusRes!.body.status, 'completed')
+  assert.equal(statusRes!.body.progress.processed, 2)
+  assert.equal(statusRes!.body.progress.total, 2)
+  assert.equal(statusRes!.body.totals.updatedOrders, 2)
+  assert.equal(statusRes!.body.totals.totalOrders, 2)
+  assert.equal(statusRes!.body.range.start <= statusRes!.body.range.end, true)
+  assert.equal(orderUpdates.length, 4)
+})
+
+test('runSettlementAdjustmentJob converts range to Asia/Jakarta boundaries', async () => {
+  const prisma = require.cache[prismaPath].exports.prisma
+  let capturedWhere: any
+  prisma.order.findMany = async ({ where }: any) => {
+    capturedWhere = where
+    return []
+  }
+  prisma.transaction_request.findMany = async () => []
+
+  const summary = await runSettlementAdjustmentJob({
+    subMerchantId: 'sub-1',
+    settlementStatus: 'SETTLED',
+    start: '2024-03-01T10:00:00Z',
+    end: '2024-03-05T10:00:00Z',
+  })
+
+  const expectedStart = moment.tz('2024-03-01T10:00:00Z', 'Asia/Jakarta').startOf('day')
+  const expectedEnd = moment.tz('2024-03-05T10:00:00Z', 'Asia/Jakarta').endOf('day')
+
+  assert.equal(capturedWhere.createdAt.gte.toISOString(), expectedStart.toDate().toISOString())
+  assert.equal(capturedWhere.createdAt.lte.toISOString(), expectedEnd.toDate().toISOString())
+  assert.equal(summary.startBoundary.toISOString(), expectedStart.toDate().toISOString())
+  assert.equal(summary.endBoundary.toISOString(), expectedEnd.toDate().toISOString())
+})
+
+test('service only updates records for requested sub-merchant', async () => {
+  const prisma = require.cache[prismaPath].exports.prisma
+  prisma.order.findMany = async () => [
+    { id: 'o1', amount: 100, fee3rdParty: 0, feeLauncx: 0, subMerchantId: 'sub-1' },
+  ]
+  prisma.transaction_request.findMany = async () => []
+  let capturedUpdateWhere: any
+  prisma.order.updateMany = async ({ where }: any) => {
+    capturedUpdateWhere = where
+    return { count: 1 }
+  }
+
+  await runSettlementAdjustmentJob({
+    subMerchantId: 'sub-1',
+    settlementStatus: 'SETTLED',
+    start: '2024-04-01',
+    end: '2024-04-02',
+  })
+
+  assert.equal(capturedUpdateWhere.subMerchantId, 'sub-1')
+})


### PR DESCRIPTION
## Summary
- extract settlement adjustment logic into a reusable service that normalizes Asia/Jakarta date ranges before applying Prisma updates
- introduce a dedicated settlement adjustment worker and API endpoints to enqueue jobs and inspect their status
- add targeted tests covering job scheduling, timezone conversion, and sub-merchant scoping for settlement adjustments

## Testing
- node --test -r ts-node/register test/settlementAdjustment.routes.test.ts test/settlementAdjustmentJob.worker.test.ts *(fails: @prisma/client not initialized in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db663aa3e483289223005b4eb762e4