### PR TITLE
Update settlement adjust job endpoint

### DIFF
--- a/frontend/src/pages/admin/settlement-adjust.tsx
+++ b/frontend/src/pages/admin/settlement-adjust.tsx
@@ -284,7 +284,7 @@ export function SettlementAdjustJobControl({
 
     try {
       const { data } = await apiClient.post<{ jobId?: string; id?: string }>(
-        '/admin/settlement/adjust/start',
+        '/admin/settlement/adjust/job',
         payload
       )
 

--- a/frontend/src/tests/settlement-adjust.test.tsx
+++ b/frontend/src/tests/settlement-adjust.test.tsx
@@ -87,7 +87,7 @@ function createApiMock() {
 
 const apiMock = createApiMock()
 
-const ADJUST_START_PATH = '/admin/settlement/adjust/start'
+const ADJUST_JOB_PATH = '/admin/settlement/adjust/job'
 const ADJUST_STATUS_PREFIX = '/admin/settlement/adjust/status/'
 
 const defaultProps: Pick<SettlementAdjustJobControlProps, 'apiClient'> = {
@@ -109,7 +109,7 @@ test('starts settlement adjust job and displays completion summary', async () =>
   let capturedPayload: any = null
 
   apiMock.setPostImplementation(async (url: string, payload: any) => {
-    if (url === ADJUST_START_PATH) {
+    if (url === ADJUST_JOB_PATH) {
       capturedPayload = payload
       return { data: { jobId: 'job-123' } }
     }


### PR DESCRIPTION
## Summary
- update the settlement adjust job control to call the new `/admin/settlement/adjust/job` endpoint
- adjust the settlement adjust test mock to cover the new endpoint path

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68dc8edf6a6c832884f50c7e0c9ccc9e