### PR TITLE
Fix loan settlement status filter

### DIFF
--- a/src/service/loanSettlement.ts
+++ b/src/service/loanSettlement.ts
@@ -236,7 +236,7 @@ export async function runLoanSettlementByRange({
     const orders = (await prisma.order.findMany({
       where: {
         subMerchantId,
-        status: { in: LOAN_ADJUSTABLE_STATUSES },
+        status: { in: [...LOAN_ADJUSTABLE_STATUSES] },
         createdAt: {
           gte: start,
           lte: end,


### PR DESCRIPTION
## Summary
- ensure the loan settlement query passes a mutable array of adjustable statuses to Prisma

## Testing
- npm run build *(fails: Module '@prisma/client' has no exported member 'DisbursementStatus')*


------
https://chatgpt.com/codex/tasks/task_e_68dce922a8648328a535f7f53ae766a6