### PR TITLE
feat: enrich loan settlement snapshots and add backfill

### DIFF
--- a/docs/loan-settlement-snapshot-backfill.md
+++ b/docs/loan-settlement-snapshot-backfill.md
@@ -1,0 +1,47 @@
+# Loan settlement snapshot backfill
+
+## Overview
+Orders that were marked as `LN_SETTLED` before the snapshot schema update may have incomplete
+metadata. The `loanSettlementHistory` and `lastLoanSettlement` entries now expect:
+
+- `previousStatus`, `previousPendingAmount`, `previousSettlementStatus`,
+  `previousSettlementAmount`, and `previousSettlementTime` values inside each snapshot.
+- Loan entry details (`id`, `subMerchantId`, `amount`, `metadata`) captured in both
+  `snapshot.loanEntry` and `snapshot.previousLoanEntry`.
+
+The `scripts/backfillLoanSettlementSnapshots.ts` script inspects existing loan-settled orders and
+fills the missing fields whenever the historical data is still available.
+
+## Running the script
+1. **Dry run (recommended):**
+   ```bash
+   npx ts-node scripts/backfillLoanSettlementSnapshots.ts --dry-run --batch=200
+   ```
+   This prints the orders that would be updated without modifying the database.
+
+2. **Apply the changes:**
+   ```bash
+   npx ts-node scripts/backfillLoanSettlementSnapshots.ts --batch=200
+   ```
+   Adjust `--batch` (default `100`) as needed. You can also cap the run with `--limit=<count>`
+   when testing in lower environments.
+
+3. **Verify:**
+   - Spot check a few updated orders to ensure `metadata.loanSettlementHistory[*].snapshot` and
+     `metadata.lastLoanSettlement.snapshot` now contain the new fields.
+   - Confirm that `loanEntry.metadata.previousLoanEntry` is present when an existing loan entry
+     was overwritten.
+
+## Historical reverts
+After the backfill completes, historical orders that were already loan-settled gain the required
+snapshot information so `revertLoanSettlementsByRange` can restore them safely. If you need to
+revert a historical settlement:
+
+1. Run the backfill script (if it has not been executed yet).
+2. Use the usual revert tooling/API; the revert flow will reuse the backfilled snapshots.
+
+## Notes
+- The script only touches orders with `status = LN_SETTLED` and leaves other records untouched.
+- Orders whose metadata is missing entirely are skipped; they will continue to require manual
+  inspection.
+- Always run the script in dry-run mode on production first to gauge the scope of the update.

--- a/scripts/backfillLoanSettlementSnapshots.ts
+++ b/scripts/backfillLoanSettlementSnapshots.ts
@@ -1,0 +1,317 @@
+import { prisma } from '../src/core/prisma';
+import { ORDER_STATUS } from '../src/types/orderStatus';
+
+const args = process.argv.slice(2);
+const dryRun = args.includes('--dry-run');
+const batchArg = args.find(arg => arg.startsWith('--batch='));
+const limitArg = args.find(arg => arg.startsWith('--limit='));
+
+const DEFAULT_BATCH_SIZE = 100;
+const batchSize = batchArg ? Math.max(1, Number(batchArg.split('=')[1])) : DEFAULT_BATCH_SIZE;
+const limit = limitArg ? Math.max(1, Number(limitArg.split('=')[1])) : null;
+
+type RawLoanEntry = {
+  id: string | null;
+  subMerchantId: string | null;
+  amount: number | null;
+  metadata: unknown;
+} | null;
+
+type OrderRecord = {
+  id: string;
+  metadata: unknown;
+  loanEntry: RawLoanEntry;
+};
+
+const jsonEqual = (a: any, b: any) => JSON.stringify(a) === JSON.stringify(b);
+
+const toNullableNumber = (value: any): number | null => {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  const num = Number(value);
+  return Number.isFinite(num) ? num : null;
+};
+
+const cloneMetadata = (value: unknown): Record<string, any> | null => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null;
+  }
+  return JSON.parse(JSON.stringify(value));
+};
+
+const cloneArray = (value: any): any[] =>
+  Array.isArray(value) ? value.map(item => (item && typeof item === 'object' ? JSON.parse(JSON.stringify(item)) : item)) : [];
+
+const normalizeLoanEntrySnapshot = (
+  value: any,
+  fallback: RawLoanEntry,
+): { snapshot: Record<string, any> | null; changed: boolean } => {
+  const parse = (source: any): Record<string, any> | null => {
+    if (!source || typeof source !== 'object') {
+      return null;
+    }
+    const record = source as Record<string, any>;
+    const id = typeof record.id === 'string' ? record.id : null;
+    const subMerchantId = typeof record.subMerchantId === 'string' ? record.subMerchantId : null;
+    const amount = toNullableNumber(record.amount);
+    const metadata =
+      record.metadata && typeof record.metadata === 'object' && !Array.isArray(record.metadata)
+        ? { ...(record.metadata as Record<string, any>) }
+        : null;
+    if (id === null && subMerchantId === null && amount === null && metadata === null) {
+      return null;
+    }
+    return { id, subMerchantId, amount, metadata };
+  };
+
+  const primary = parse(value);
+  const fallbackParsed = parse(fallback);
+
+  if (!primary && !fallbackParsed) {
+    return { snapshot: null, changed: Boolean(value) };
+  }
+
+  const snapshot = {
+    id: primary?.id ?? fallbackParsed?.id ?? null,
+    subMerchantId: primary?.subMerchantId ?? fallbackParsed?.subMerchantId ?? null,
+    amount:
+      primary && primary.amount !== null
+        ? primary.amount
+        : fallbackParsed && fallbackParsed.amount !== null
+        ? fallbackParsed.amount
+        : null,
+    metadata: primary?.metadata ?? fallbackParsed?.metadata ?? null,
+  };
+
+  const changed = !jsonEqual(primary ?? null, snapshot);
+  return { snapshot, changed };
+};
+
+const ensureSnapshot = (
+  snapshotValue: any,
+  orderLoanEntry: RawLoanEntry,
+): { snapshot: Record<string, any>; changed: boolean } => {
+  const snapshot = snapshotValue && typeof snapshotValue === 'object' && !Array.isArray(snapshotValue)
+    ? { ...(snapshotValue as Record<string, any>) }
+    : {};
+  let changed = false;
+
+  const resolvedStatus =
+    typeof snapshot.previousStatus === 'string'
+      ? snapshot.previousStatus
+      : typeof snapshot.status === 'string'
+      ? snapshot.status
+      : null;
+  if (snapshot.status !== resolvedStatus) {
+    snapshot.status = resolvedStatus;
+    changed = true;
+  }
+  if (snapshot.previousStatus !== resolvedStatus) {
+    snapshot.previousStatus = resolvedStatus;
+    changed = true;
+  }
+
+  const resolvedPending = toNullableNumber(
+    snapshot.previousPendingAmount !== undefined ? snapshot.previousPendingAmount : snapshot.pendingAmount,
+  );
+  if (snapshot.pendingAmount !== resolvedPending) {
+    snapshot.pendingAmount = resolvedPending;
+    changed = true;
+  }
+  if (snapshot.previousPendingAmount !== resolvedPending) {
+    snapshot.previousPendingAmount = resolvedPending;
+    changed = true;
+  }
+
+  const resolvedSettlementStatus =
+    typeof snapshot.previousSettlementStatus === 'string'
+      ? snapshot.previousSettlementStatus
+      : typeof snapshot.settlementStatus === 'string'
+      ? snapshot.settlementStatus
+      : null;
+  if (snapshot.settlementStatus !== resolvedSettlementStatus) {
+    snapshot.settlementStatus = resolvedSettlementStatus;
+    changed = true;
+  }
+  if (snapshot.previousSettlementStatus !== resolvedSettlementStatus) {
+    snapshot.previousSettlementStatus = resolvedSettlementStatus;
+    changed = true;
+  }
+
+  const resolvedSettlementAmount = toNullableNumber(
+    snapshot.previousSettlementAmount !== undefined
+      ? snapshot.previousSettlementAmount
+      : snapshot.settlementAmount,
+  );
+  if (snapshot.settlementAmount !== resolvedSettlementAmount) {
+    snapshot.settlementAmount = resolvedSettlementAmount;
+    changed = true;
+  }
+  if (snapshot.previousSettlementAmount !== resolvedSettlementAmount) {
+    snapshot.previousSettlementAmount = resolvedSettlementAmount;
+    changed = true;
+  }
+
+  const resolvedSettlementTime =
+    typeof snapshot.previousSettlementTime === 'string'
+      ? snapshot.previousSettlementTime
+      : typeof snapshot.settlementTime === 'string'
+      ? snapshot.settlementTime
+      : null;
+  if (snapshot.settlementTime !== resolvedSettlementTime) {
+    snapshot.settlementTime = resolvedSettlementTime;
+    changed = true;
+  }
+  if (snapshot.previousSettlementTime !== resolvedSettlementTime) {
+    snapshot.previousSettlementTime = resolvedSettlementTime;
+    changed = true;
+  }
+
+  const loanEntryResult = normalizeLoanEntrySnapshot(snapshot.loanEntry, orderLoanEntry);
+  if (!jsonEqual(snapshot.loanEntry ?? null, loanEntryResult.snapshot)) {
+    snapshot.loanEntry = loanEntryResult.snapshot;
+    changed = true;
+  }
+  if (!jsonEqual(snapshot.previousLoanEntry ?? null, loanEntryResult.snapshot)) {
+    snapshot.previousLoanEntry = loanEntryResult.snapshot;
+    changed = true;
+  }
+  if (loanEntryResult.changed) {
+    changed = true;
+  }
+
+  return { snapshot, changed };
+};
+
+const backfillHistoryEntry = (
+  entryValue: any,
+  order: OrderRecord,
+): { entry: Record<string, any>; changed: boolean } => {
+  if (!entryValue || typeof entryValue !== 'object' || Array.isArray(entryValue)) {
+    return { entry: entryValue, changed: false } as any;
+  }
+
+  const entry = { ...(entryValue as Record<string, any>) };
+  let changed = false;
+
+  if (entry.snapshot) {
+    const { snapshot, changed: snapshotChanged } = ensureSnapshot(entry.snapshot, order.loanEntry);
+    if (snapshotChanged) {
+      entry.snapshot = snapshot;
+      changed = true;
+    }
+  }
+
+  const snapshotStatus =
+    entry.snapshot && typeof entry.snapshot === 'object'
+      ? entry.snapshot.previousStatus ?? entry.snapshot.status
+      : null;
+  if (snapshotStatus && entry.previousStatus !== snapshotStatus) {
+    entry.previousStatus = snapshotStatus;
+    changed = true;
+  }
+
+  return { entry, changed };
+};
+
+const backfillOrderMetadata = (order: OrderRecord): { metadata: Record<string, any>; changed: boolean } => {
+  const metadata = cloneMetadata(order.metadata);
+  if (!metadata) {
+    return { metadata: {}, changed: false };
+  }
+
+  let changed = false;
+
+  if (Array.isArray(metadata.loanSettlementHistory)) {
+    const history = cloneArray(metadata.loanSettlementHistory).map(item => {
+      const { entry, changed: entryChanged } = backfillHistoryEntry(item, order);
+      if (entryChanged) {
+        changed = true;
+      }
+      return entry;
+    });
+    metadata.loanSettlementHistory = history;
+  }
+
+  if (metadata.lastLoanSettlement && typeof metadata.lastLoanSettlement === 'object') {
+    const { entry, changed: entryChanged } = backfillHistoryEntry(metadata.lastLoanSettlement, order);
+    if (entryChanged) {
+      metadata.lastLoanSettlement = entry;
+      changed = true;
+    }
+  }
+
+  return { metadata, changed };
+};
+
+async function main() {
+  let processed = 0;
+  let updated = 0;
+  let cursor: string | null = null;
+
+  while (true) {
+    const orders = (await prisma.order.findMany({
+      where: { status: ORDER_STATUS.LN_SETTLED },
+      orderBy: { id: 'asc' },
+      take: batchSize,
+      ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
+      select: {
+        id: true,
+        metadata: true,
+        loanEntry: {
+          select: {
+            id: true,
+            subMerchantId: true,
+            amount: true,
+            metadata: true,
+          },
+        },
+      },
+    })) as OrderRecord[];
+
+    if (orders.length === 0) {
+      break;
+    }
+
+    for (const order of orders) {
+      processed += 1;
+      const { metadata, changed } = backfillOrderMetadata(order);
+      if (changed) {
+        updated += 1;
+        if (dryRun) {
+          console.log(`[DRY-RUN] Would backfill loan snapshot for order ${order.id}`);
+        } else {
+          await prisma.order.update({ where: { id: order.id }, data: { metadata } });
+          console.log(`[UPDATE] Backfilled loan snapshot for order ${order.id}`);
+        }
+      }
+
+      if (limit && processed >= limit) {
+        break;
+      }
+    }
+
+    if (limit && processed >= limit) {
+      break;
+    }
+
+    cursor = orders[orders.length - 1].id;
+  }
+
+  console.log(`Processed ${processed} loan-settled orders.`);
+  if (dryRun) {
+    console.log(`Dry-run complete. ${updated} orders would be updated.`);
+  } else {
+    console.log(`Updated ${updated} orders with normalized loan settlement snapshots.`);
+  }
+}
+
+main()
+  .catch(err => {
+    console.error(err);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/src/controller/admin/loan.controller.ts
+++ b/src/controller/admin/loan.controller.ts
@@ -20,6 +20,7 @@ import {
   type OrderForLoanSettlement,
   type LoanSettlementUpdate,
   createLoanSettlementAuditEntry,
+  createLoanEntrySnapshot,
   type LoanSettlementRevertSummary,
 } from '../../service/loanSettlement';
 import {
@@ -162,6 +163,8 @@ export async function markLoanOrdersSettled(req: AuthRequest, res: Response) {
         createdAt: true,
         loanEntry: {
           select: {
+            id: true,
+            subMerchantId: true,
             amount: true,
             metadata: true,
           },
@@ -229,6 +232,7 @@ export async function markLoanOrdersSettled(req: AuthRequest, res: Response) {
         pendingAmount: order.pendingAmount,
         originalStatus: order.status,
         settlementAmount: order.settlementAmount,
+        previousLoanEntry: createLoanEntrySnapshot(order.loanEntry),
       });
     }
 


### PR DESCRIPTION
## Summary
- enrich loan settlement metadata with previous values and loan entry snapshots
- adjust revert/update flows and tests to consume the expanded snapshot fields
- add a backfill utility and documentation to normalize historical LN_SETTLED orders

## Testing
- node --test -r ts-node/register test/adminLoan.routes.test.ts test/loanSettlement.service.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68ddcbb332848328be252f3cc26061d6