### PR TITLE
Add loan revert mode with manual order export support

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,6 +38,7 @@
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.10",
     "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^20.19.1",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19",

--- a/frontend/src/utils/download.ts
+++ b/frontend/src/utils/download.ts
@@ -1,0 +1,32 @@
+export type ExportFilePayload = {
+  data: string
+  mimeType?: string | null
+  fileName?: string | null
+  filename?: string | null
+}
+
+export function downloadExportFile(exportFile: ExportFilePayload | null | undefined, fallbackName = 'export.csv') {
+  if (!exportFile?.data) {
+    return
+  }
+
+  const binaryString = typeof window !== 'undefined' ? window.atob(exportFile.data) : Buffer.from(exportFile.data, 'base64').toString('binary')
+  const len = binaryString.length
+  const bytes = new Uint8Array(len)
+  for (let i = 0; i < len; i += 1) {
+    bytes[i] = binaryString.charCodeAt(i)
+  }
+
+  const type = exportFile.mimeType ?? 'text/csv'
+  const blob = new Blob([bytes], { type })
+  const downloadName = exportFile.fileName || exportFile.filename || fallbackName
+
+  const url = URL.createObjectURL(blob)
+  const anchor = document.createElement('a')
+  anchor.href = url
+  anchor.download = downloadName
+  document.body.appendChild(anchor)
+  anchor.click()
+  document.body.removeChild(anchor)
+  URL.revokeObjectURL(url)
+}


### PR DESCRIPTION
## Summary
- add a revert mode alongside the existing mark flow in the admin loan page, including LN_SETTLED filtering and combined selection counts
- wire manual order entry and CSV export handling through the new download helper when calling the revert API
- extend the loan page tests to cover revert/export payloads, manual IDs, and file download behavior

## Testing
- npm --prefix frontend run test -- src/tests/loan.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68ddd1673a4c8328b4111295eab16980