### PR TITLE
Extend loan audit tracking

### DIFF
--- a/src/controller/admin/loan.controller.ts
+++ b/src/controller/admin/loan.controller.ts
@@ -95,6 +95,10 @@ export async function getLoanTransactions(req: AuthRequest, res: Response) {
           pendingAmount: true,
           status: true,
           createdAt: true,
+          isLoan: true,
+          loanAmount: true,
+          loanAt: true,
+          loanBy: true,
           loanedAt: true,
           loanEntry: {
             select: {
@@ -115,9 +119,14 @@ export async function getLoanTransactions(req: AuthRequest, res: Response) {
       pendingAmount: order.pendingAmount ?? 0,
       status: order.status,
       createdAt: order.createdAt.toISOString(),
+      isLoan: order.isLoan,
       loanedAt: order.loanedAt ? order.loanedAt.toISOString() : null,
-      loanAmount: order.loanEntry?.amount ?? null,
-      loanCreatedAt: order.loanEntry?.createdAt
+      loanAt: order.loanAt ? order.loanAt.toISOString() : null,
+      loanBy: order.loanBy ?? null,
+      loanAmount: order.loanAmount ?? order.loanEntry?.amount ?? null,
+      loanCreatedAt: order.loanAt
+        ? order.loanAt.toISOString()
+        : order.loanEntry?.createdAt
         ? order.loanEntry.createdAt.toISOString()
         : null,
     }));
@@ -159,6 +168,10 @@ export async function markLoanOrdersSettled(req: AuthRequest, res: Response) {
         settlementTime: true,
         metadata: true,
         subMerchantId: true,
+        isLoan: true,
+        loanAmount: true,
+        loanAt: true,
+        loanBy: true,
         loanedAt: true,
         createdAt: true,
         loanEntry: {

--- a/src/controller/admin/merchant.controller.ts
+++ b/src/controller/admin/merchant.controller.ts
@@ -468,6 +468,10 @@ export async function getDashboardTransactions(req: Request, res: Response) {
           paymentReceivedTime:  true,  // ← baru
           settlementTime:       true,  // ← baru
           trxExpirationTime:    true,  // ← barus
+          isLoan:               true,
+          loanAmount:           true,
+          loanAt:               true,
+          loanBy:               true,
           loanedAt:             true,
           loanEntry: {
             select: {
@@ -514,8 +518,12 @@ export async function getDashboardTransactions(req: Request, res: Response) {
                                ? o.trxExpirationTime.toISOString()
                                : '',
         loanedAt:             o.loanedAt ? o.loanedAt.toISOString() : '',
-        loanAmount:           o.loanEntry?.amount ?? null,
-        loanCreatedAt:        o.loanEntry?.createdAt
+        loanAt:               o.loanAt ? o.loanAt.toISOString() : '',
+        loanBy:               o.loanBy ?? '',
+        loanAmount:           o.loanAmount ?? o.loanEntry?.amount ?? null,
+        loanCreatedAt:        o.loanAt
+                               ? o.loanAt.toISOString()
+                               : o.loanEntry?.createdAt
                                ? o.loanEntry.createdAt.toISOString()
                                : null,
       }

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -63,6 +63,7 @@ model sub_merchant {
   orders           Order[]             @relation("OrderSubMerchant")
   loanEntries     LoanEntry[]         @relation("SubMerchantLoanEntries")
   balanceRecords  SubMerchantBalance[] @relation("SubMerchantBalanceSubMerchant")
+  loanSettlementJobs LoanSettlementJob[] @relation("SubMerchantLoanSettlementJobs")
 
 
 
@@ -234,6 +235,10 @@ model Order {
   paymentReceivedTime  DateTime?      // full.payment_received_time
   settlementTime       DateTime?      // full.settlement_time
   trxExpirationTime    DateTime?      // full.trx_expiration_time
+  isLoan           Boolean   @default(false)
+  loanAmount       Float?
+  loanAt           DateTime?
+  loanBy           String?
   loanedAt         DateTime?
   createdAt        DateTime         @default(now())
   updatedAt        DateTime         @updatedAt
@@ -260,6 +265,26 @@ model LoanEntry {
   @@index([subMerchantId])
 }
 
+model LoanSettlementJob {
+  id              String      @id @default(uuid()) @map("_id")
+  subMerchantId   String
+  startDate       DateTime
+  endDate         DateTime
+  totalOrder      Int         @default(0)
+  totalLoanAmount Float       @default(0)
+  status          String
+  createdBy       String?
+  createdAt       DateTime    @default(now())
+  updatedAt       DateTime    @updatedAt
+
+  subMerchant sub_merchant @relation("SubMerchantLoanSettlementJobs", fields: [subMerchantId], references: [id])
+  creator     PartnerUser?  @relation("LoanSettlementJobCreatedBy", fields: [createdBy], references: [id])
+
+  @@index([subMerchantId])
+  @@index([status])
+  @@index([createdBy])
+}
+
 /// PartnerUser untuk login admin
 model PartnerUser {
   id        String   @id @default(uuid()) @map("_id")
@@ -273,6 +298,7 @@ model PartnerUser {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   logs      AdminLog[]
+  loanSettlementJobs LoanSettlementJob[] @relation("LoanSettlementJobCreatedBy")
 
 }
 


### PR DESCRIPTION
## Summary
- add loan audit fields to the `Order` model and introduce the `LoanSettlementJob` collection in the Prisma schema
- propagate the new audit fields through loan settlement services and admin controllers, including richer revert exports
- regenerate the Prisma client after the schema changes

## Testing
- CI=1 DATABASE_URL="mongodb://localhost:27017/test" npx prisma generate --schema src/prisma/schema.prisma

------
https://chatgpt.com/codex/tasks/task_e_68de34e6cb7883288d9baeb838a5ecfe