### PR TITLE
Add dry-run tracking and history for loan settlement jobs

### DIFF
--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -273,6 +273,7 @@ model LoanSettlementJob {
   totalOrder      Int         @default(0)
   totalLoanAmount Float       @default(0)
   status          String
+  dryRun          Boolean     @default(false)
   createdBy       String?
   createdAt       DateTime    @default(now())
   updatedAt       DateTime    @updatedAt

--- a/src/route/admin/merchant.routes.ts
+++ b/src/route/admin/merchant.routes.ts
@@ -56,6 +56,7 @@ router.get(
   '/loan/mark-settled/by-range/status/:jobId',
   loanCtrl.loanSettlementJobStatus,
 )
+router.get('/loan/mark-settled/by-range/jobs', loanCtrl.listLoanSettlementJobs)
 
 router.get('/dashboard/withdrawals',  ctrl.getDashboardWithdrawals)
 router.patch(


### PR DESCRIPTION
## Summary
- persist loan settlement jobs with a dry-run flag and expose status/history APIs for admins
- update loan settlement processing to synchronize job progress with the database and reuse cron-style logging
- enhance the admin loan management UI with dry-run controls, live progress, and job history data

## Testing
- node --test -r ts-node/register test/loanSettlementJob.worker.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68de3c50d4fc8328a14a26b163d0672c