### PR TITLE
Add manual client withdrawal entry support

### DIFF
--- a/frontend/src/components/dashboard/WithdrawalHistory.tsx
+++ b/frontend/src/components/dashboard/WithdrawalHistory.tsx
@@ -115,12 +115,14 @@ export default function WithdrawalHistory(_: any) {
     if (!withdrawals?.length) return
     const headers = [
       'Date','Ref ID','Account Name','Alias','Account No.','Bank Code','Bank Name','Branch',
-      'Wallet/Submerchant','Withdrawal Fee','Amount','Net Amount','PG Fee','PG Trx ID','In Process','Status','Completed At',
+      'Wallet/Submerchant','Source','Withdrawal Fee','Amount','Net Amount','PG Fee','PG Trx ID','In Process','Status','Completed At',
     ]
     const rows = withdrawals.map((w) => [
       new Date(w.createdAt).toLocaleString('id-ID', { dateStyle: 'short', timeStyle: 'short' }),
       w.refId ?? '', w.accountName ?? '', w.accountNameAlias ?? '', w.accountNumber ?? '',
-      w.bankCode ?? '', w.bankName ?? '', w.branchName ?? '', w.wallet ?? '',
+      w.bankCode ?? '', w.bankName ?? '', w.branchName ?? '',
+      w.sourceProvider === 'manual' ? 'Manual Entry' : w.wallet ?? '',
+      w.sourceProvider ?? '',
       (w.amount - (w.netAmount ?? 0)).toString(),
       w.amount.toString(),
       w.netAmount?.toString() ?? '',
@@ -258,9 +260,9 @@ export default function WithdrawalHistory(_: any) {
               <table className="min-w-[1200px] w-full text-sm">
                 <thead className="sticky top-0 z-10">
                   <tr className="border-b bg-neutral-50/80 backdrop-blur dark:border-neutral-800 dark:bg-neutral-900/80">
-                    {[
+                    {[ 
                       'Date','Ref ID','Account Name','Alias','Account No.','Bank Code','Bank Name','Branch',
-                      'Wallet/Submerchant','Withdrawal Fee','Amount','Net Amount','PG Fee','PG Trx ID','In Process','Status','Completed At','Actions',
+                      'Wallet/Submerchant','Source','Withdrawal Fee','Amount','Net Amount','PG Fee','PG Trx ID','In Process','Status','Completed At','Actions',
                     ].map((h) => (
                       <th key={h} className="px-3 py-2 text-left font-medium text-neutral-700 dark:text-neutral-300">
                         {h}
@@ -284,7 +286,8 @@ export default function WithdrawalHistory(_: any) {
                       <td className="px-3 py-2">{w.bankCode}</td>
                       <td className="px-3 py-2">{w.bankName}</td>
                       <td className="px-3 py-2">{w.branchName ?? '-'}</td>
-                      <td className="px-3 py-2">{w.wallet}</td>
+                      <td className="px-3 py-2">{w.sourceProvider === 'manual' ? 'Manual Entry' : w.wallet}</td>
+                      <td className="px-3 py-2">{w.sourceProvider ?? '-'}</td>
                       <td className="px-3 py-2 whitespace-nowrap">
                         {(w.amount - (w.netAmount ?? 0)).toLocaleString('id-ID', { style: 'currency', currency: 'IDR' })}
                       </td>

--- a/frontend/src/pages/client/WithdrawPage.module.css
+++ b/frontend/src/pages/client/WithdrawPage.module.css
@@ -133,6 +133,100 @@
 .input,.select { padding:.5rem .75rem; border:1px solid #d1d5db; border-radius:8px;
                  font-size:.875rem; }
 
+.toast {
+  margin-bottom: 1rem;
+  display: flex;
+  align-items: center;
+  gap: .75rem;
+  border-radius: 12px;
+  padding: .75rem 1rem;
+  font-size: .875rem;
+  border: 1px solid transparent;
+}
+.toastSuccess {
+  background: #ecfdf5;
+  border-color: #a7f3d0;
+  color: #047857;
+}
+.toastError {
+  background: #fef2f2;
+  border-color: #fecaca;
+  color: #b91c1c;
+}
+.toastIcon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.manualHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+.manualGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+  margin-top: 1rem;
+}
+.manualField {
+  display: flex;
+  flex-direction: column;
+  gap: .5rem;
+}
+.manualField label {
+  font-size: .875rem;
+  color: #4b5563;
+}
+.manualField input,
+.manualField select {
+  padding: .65rem .75rem;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  font-size: .9rem;
+  background: #fff;
+}
+.manualField input:focus,
+.manualField select:focus {
+  outline: none;
+  border-color: #6366f1;
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, .15);
+}
+.manualSummary {
+  margin-top: 1rem;
+  font-size: .9rem;
+  color: #374151;
+}
+.manualSummary strong {
+  color: #111827;
+}
+.manualActions {
+  margin-top: 1.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: .75rem;
+  grid-column: 1 / -1;
+}
+.manualSubmit {
+  background: #6366f1;
+  color: #fff;
+  border: none;
+  border-radius: 10px;
+  padding: .75rem 1.5rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background .2s ease;
+}
+.manualSubmit:hover {
+  background: #4f46e5;
+}
+.manualSubmit:disabled {
+  opacity: .6;
+  cursor: not-allowed;
+}
+
 .tableWrap  { overflow-x:auto; border-radius:12px; }
 .table      { width:100%; border-collapse:collapse; }
 .table th,

--- a/frontend/src/pages/client/withdraw.tsx
+++ b/frontend/src/pages/client/withdraw.tsx
@@ -27,6 +27,7 @@ interface Withdrawal {
   status: string
   createdAt: string
   completedAt?: string
+  sourceProvider?: string
 }
 interface SubMerchant {
   id: string
@@ -311,12 +312,14 @@ export default function WithdrawPage() {
 
   const exportToExcel = () => {
     const rows = [
-      ['Created At','Completed At','Ref ID','Bank','Account','Account Name','Wallet','Amount','Fee','Net Amount','Status'],
+      ['Created At','Completed At','Ref ID','Bank','Account','Account Name','Wallet','Source','Amount','Fee','Net Amount','Status'],
       ...withdrawals.map(w => [
         new Date(w.createdAt).toLocaleString('id-ID',{ dateStyle:'short', timeStyle:'short' }),
         w.completedAt ? new Date(w.completedAt).toLocaleString('id-ID',{ dateStyle:'short', timeStyle:'short' }) : '-',
         w.refId, w.bankName, w.accountNumber, w.accountName, w.wallet,
-        w.amount, w.amount - w.netAmount, w.netAmount, w.status
+        w.sourceProvider === 'manual' ? 'Manual Entry' : w.wallet,
+        w.sourceProvider ?? '',
+        w.amount, w.amount - (w.netAmount ?? 0), w.netAmount ?? 0, w.status
       ])
     ]
     const ws = XLSX.utils.aoa_to_sheet(rows)
@@ -502,7 +505,7 @@ export default function WithdrawPage() {
               <table className="min-w-[1100px] w-full text-sm">
                 <thead className="sticky top-0 z-10">
                   <tr className="border-b border-neutral-800 bg-neutral-900/80 backdrop-blur">
-                    {['Created At','Completed At','Ref ID','Bank','Account','Account Name','Wallet','Amount','Fee','Net Amount','Status'].map(h => (
+                    {['Created At','Completed At','Ref ID','Bank','Account','Account Name','Wallet','Source','Amount','Fee','Net Amount','Status'].map(h => (
                       <th key={h} className="px-3 py-2 text-left font-medium text-neutral-300">
                         <span className="inline-flex items-center gap-1">{h}<ArrowUpDown size={14} className="opacity-50" /></span>
                       </th>
@@ -522,10 +525,11 @@ export default function WithdrawPage() {
                       <td className="px-3 py-2">{w.bankName}</td>
                       <td className="px-3 py-2">{w.accountNumber}</td>
                       <td className="px-3 py-2">{w.accountName}</td>
-                      <td className="px-3 py-2">{w.wallet}</td>
+                      <td className="px-3 py-2">{w.sourceProvider === 'manual' ? 'Manual Entry' : w.wallet}</td>
+                      <td className="px-3 py-2">{w.sourceProvider ?? '-'}</td>
                       <td className="px-3 py-2 whitespace-nowrap">Rp {w.amount.toLocaleString()}</td>
-                      <td className="px-3 py-2 whitespace-nowrap">Rp {(w.amount - w.netAmount).toLocaleString()}</td>
-                      <td className="px-3 py-2 whitespace-nowrap font-semibold">Rp {w.netAmount.toLocaleString()}</td>
+                      <td className="px-3 py-2 whitespace-nowrap">Rp {(w.amount - (w.netAmount ?? 0)).toLocaleString()}</td>
+                      <td className="px-3 py-2 whitespace-nowrap font-semibold">Rp {(w.netAmount ?? 0).toLocaleString()}</td>
                       <td className="px-3 py-2">
                         <span className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium
                           ${w.status === 'COMPLETED'
@@ -541,7 +545,7 @@ export default function WithdrawPage() {
                     </tr>
                   )) : (
                     <tr>
-                      <td colSpan={11} className="px-3 py-10 text-center text-neutral-400">No data</td>
+                      <td colSpan={12} className="px-3 py-10 text-center text-neutral-400">No data</td>
                     </tr>
                   )}
                 </tbody>

--- a/frontend/src/types/dashboard.ts
+++ b/frontend/src/types/dashboard.ts
@@ -35,6 +35,7 @@ export interface Withdrawal {
   createdAt: string
   completedAt?: string
   wallet: string
+  sourceProvider?: string
 }
 
 export type WithdrawalUpdate = Partial<

--- a/src/controller/admin/merchant.controller.ts
+++ b/src/controller/admin/merchant.controller.ts
@@ -734,6 +734,7 @@ export async function getDashboardWithdrawals(req: Request, res: Response) {
           completedAt:       true,
           withdrawFeePercent: true,
           withdrawFeeFlat:    true,
+          sourceProvider:    true,
           subMerchant: { select: { name: true, provider: true } },
         },
       }),
@@ -759,7 +760,11 @@ export async function getDashboardWithdrawals(req: Request, res: Response) {
       status:            w.status,
       createdAt:         w.createdAt.toISOString(),
       completedAt:       w.completedAt?.toISOString() ?? null,
-      wallet:            w.subMerchant?.name || w.subMerchant?.provider,
+      wallet:
+        w.sourceProvider === 'manual'
+          ? 'Manual Entry'
+          : w.subMerchant?.name || w.subMerchant?.provider,
+      sourceProvider:    w.sourceProvider,
 
     }));
 

--- a/src/controller/withdrawals.controller.ts
+++ b/src/controller/withdrawals.controller.ts
@@ -190,6 +190,7 @@ export async function listWithdrawals(req: ClientAuthRequest, res: Response) {
         status:        true,
         createdAt:     true,
         completedAt:   true,
+        sourceProvider: true,
         subMerchant: { select: { name: true, provider: true } },
 
       },
@@ -213,7 +214,11 @@ export async function listWithdrawals(req: ClientAuthRequest, res: Response) {
     status:        w.status,
     createdAt:     w.createdAt.toISOString(),
     completedAt:   w.completedAt?.toISOString() ?? null,
-    wallet:        w.subMerchant?.name ?? w.subMerchant?.provider ?? null,
+    wallet:
+      w.sourceProvider === 'manual'
+        ? 'Manual Entry'
+        : w.subMerchant?.name ?? w.subMerchant?.provider ?? null,
+    sourceProvider: w.sourceProvider,
 
   }));
 

--- a/src/route/admin/client.routes.ts
+++ b/src/route/admin/client.routes.ts
@@ -24,6 +24,12 @@ router.get('/providers',       ctrl.listProviders)
 router.get('/:clientId/dashboard', ctrl.getClientDashboardAdmin)
 router.get('/:clientId/withdrawals', ctrl.getClientWithdrawalsAdmin)
 router.get('/:clientId/subwallets',  ctrl.getClientSubWallets)
+router.post(
+  '/:clientId/withdrawals/manual',
+  validator.manualClientWithdrawValidation,
+  validator.handleValidationErrors,
+  ctrl.createClientManualWithdrawal,
+)
 router.post('/:clientId/reconcile-balance', ctrl.reconcileClientBalance)
 router.patch(
   '/:clientId/balance',

--- a/src/validation/validation.ts
+++ b/src/validation/validation.ts
@@ -254,6 +254,52 @@ const adjustClientBalanceValidation = [
   }),
 ];
 
+const manualClientWithdrawValidation = [
+  body('subMerchantId')
+    .isString()
+    .notEmpty()
+    .withMessage('subMerchantId is required'),
+  body('amount')
+    .isFloat({ min: 0 })
+    .withMessage('Amount must be a non-negative number'),
+  body('accountName')
+    .isString()
+    .notEmpty()
+    .withMessage('accountName is required'),
+  body('accountNumber')
+    .isString()
+    .notEmpty()
+    .withMessage('accountNumber is required'),
+  body('bankCode')
+    .isString()
+    .notEmpty()
+    .withMessage('bankCode is required'),
+  body('bankName')
+    .isString()
+    .notEmpty()
+    .withMessage('bankName is required'),
+  body('accountNameAlias')
+    .optional()
+    .isString()
+    .withMessage('accountNameAlias must be a string'),
+  body('branchName')
+    .optional()
+    .isString()
+    .withMessage('branchName must be a string'),
+  body('withdrawFeePercent')
+    .optional()
+    .isFloat({ min: 0 })
+    .withMessage('withdrawFeePercent must be a non-negative number'),
+  body('withdrawFeeFlat')
+    .optional()
+    .isFloat({ min: 0 })
+    .withMessage('withdrawFeeFlat must be a non-negative number'),
+  body('pgFee')
+    .optional()
+    .isFloat({ min: 0 })
+    .withMessage('pgFee must be a non-negative number'),
+];
+
 const validation = {
   handleValidationErrors,
   initiatePaymentValidation,
@@ -264,6 +310,7 @@ const validation = {
   createCardSessionValidation,
   confirmCardSessionValidation,
   adjustClientBalanceValidation,
+  manualClientWithdrawValidation,
 };
 
 export default validation;


### PR DESCRIPTION
## Summary
- add an admin manual-withdrawal handler that validates inputs, logs actions, and records completed payouts with a manual source provider
- include source provider metadata in withdrawal listings so manual entries surface consistently across dashboards
- extend the admin client withdraw UI with a manual entry form, toast feedback, and manual/source labels while updating client dashboards to show the new source info

## Testing
- npm run lint *(fails: interactive configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68de417505c48328898bee2272d4f225