### PR TITLE
Handle manual settlement without external lookups

### DIFF
--- a/src/service/billing.ts
+++ b/src/service/billing.ts
@@ -1,0 +1,43 @@
+import axios from 'axios'
+
+import logger from '../logger'
+
+export interface BalanceMovementPayload {
+  partnerClientId: string
+  amount: number
+  reference: string
+  description?: string
+}
+
+const DEFAULT_TIMEOUT = Number(process.env.BILLING_SERVICE_TIMEOUT_MS ?? 15_000)
+
+function resolveBaseUrl() {
+  return (process.env.BILLING_SERVICE_URL || '').replace(/\/$/, '')
+}
+
+export async function postBalanceMovement(payload: BalanceMovementPayload): Promise<void> {
+  const baseUrl = resolveBaseUrl()
+  if (!baseUrl) {
+    logger.warn('[BillingService] BILLING_SERVICE_URL not configured, skipping movement', payload)
+    return
+  }
+
+  try {
+    await axios.post(
+      `${baseUrl}/balance-movements`,
+      payload,
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          ...(process.env.BILLING_SERVICE_API_KEY
+            ? { 'x-api-key': process.env.BILLING_SERVICE_API_KEY }
+            : {}),
+        },
+        timeout: DEFAULT_TIMEOUT,
+      }
+    )
+  } catch (err) {
+    logger.error('[BillingService] Failed to post balance movement', err)
+    throw err
+  }
+}

--- a/test/runManualSettlement.test.ts
+++ b/test/runManualSettlement.test.ts
@@ -9,12 +9,18 @@ delete process.env.npm_config_https_proxy
 
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import nock from 'nock'
 import { runManualSettlement, resetSettlementState } from '../src/cron/settlement'
+import * as billing from '../src/service/billing'
 import { prisma } from '../src/core/prisma'
 
 test('runManualSettlement settles PAID orders', async () => {
   resetSettlementState()
+
+  const movements: billing.BalanceMovementPayload[] = []
+  const originalPost = billing.postBalanceMovement
+  ;(billing as any).postBalanceMovement = async (payload: billing.BalanceMovementPayload) => {
+    movements.push(payload)
+  }
 
   let firstCall = true
   ;(prisma as any).order = {
@@ -26,40 +32,37 @@ test('runManualSettlement settles PAID orders', async () => {
             id: 'o1',
             partnerClientId: 'pc1',
             pendingAmount: 100,
+            amount: 150,
             channel: 'oy',
             createdAt: new Date(Date.now() - 1000),
-            subMerchant: { credentials: { merchantId: 'm1', secretKey: 's1' } }
+            rrn: null,
+            subMerchant: null,
+            partnerClient: { id: 'pc1', feePercent: 1, feeFlat: 0 }
           }
         ]
       }
       return []
-    }
+    },
+    updateMany: async () => ({ count: 1 })
   }
 
   ;(prisma as any).$queryRaw = async () => [{ locked: true }]
 
+  const orderUpdates: any[] = []
+  const partnerUpdates: any[] = []
   ;(prisma as any).$transaction = async (fn: any) =>
     fn({
-      order: { updateMany: async () => ({ count: 1 }) },
-      partnerClient: { update: async () => {} }
-    })
-
-  const scope1 = nock('https://partner.oyindonesia.com')
-    .post('/api/payment-routing/check-status')
-    .reply(200, {
-      status: { code: '000' },
-      trx_id: 'trx1',
-      settlement_status: 'SETTLED'
-    })
-  const scope2 = nock('https://partner.oyindonesia.com')
-    .get('/api/v1/transaction')
-    .query(true)
-    .reply(200, {
-      status: { code: '000' },
-      data: {
-        settlement_amount: 100,
-        admin_fee: { total_fee: 1 },
-        settlement_time: new Date().toISOString()
+      order: {
+        updateMany: async (args: any) => {
+          orderUpdates.push(args)
+          return { count: 1 }
+        }
+      },
+      partnerClient: {
+        update: async (args: any) => {
+          partnerUpdates.push(args)
+          return {}
+        }
       }
     })
 
@@ -67,7 +70,24 @@ test('runManualSettlement settles PAID orders', async () => {
 
   assert.equal(result.settledOrders, 1)
   assert.equal(result.netAmount, 100)
-  scope1.done()
-  scope2.done()
+  assert.equal(movements.length, 1)
+  assert.deepEqual(movements[0], {
+    partnerClientId: 'pc1',
+    amount: 100,
+    reference: 'SETTLE:o1',
+    description: 'Manual settlement for order o1'
+  })
+  assert.equal(orderUpdates.length, 1)
+  assert.equal(orderUpdates[0].data.status, 'SETTLED')
+  assert.equal(orderUpdates[0].data.settlementAmount, 100)
+  assert.equal(orderUpdates[0].data.settlementStatus, 'MANUAL')
+  assert.ok(orderUpdates[0].data.settlementTime instanceof Date)
+  assert.equal(partnerUpdates.length, 1)
+  assert.deepEqual(partnerUpdates[0], {
+    where: { id: 'pc1' },
+    data: { balance: { increment: 100 } }
+  })
+
+  ;(billing as any).postBalanceMovement = originalPost
 })
 


### PR DESCRIPTION
## Summary
- compute manual settlement batches without hitting external provider APIs and send idempotent ledger movements
- introduce a billing client helper for posting partner balance movements
- update the manual settlement test to validate the internal computation and ledger call path

## Testing
- node --test -r ts-node/register test/runManualSettlement.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68df8c6cff808328985690c9a3b6b143