### PR TITLE
feat: add filtered manual settlement controls and reporting

### DIFF
--- a/frontend/src/pages/admin/settlement.tsx
+++ b/frontend/src/pages/admin/settlement.tsx
@@ -1,76 +1,282 @@
 'use client'
 
 import { useEffect, useMemo, useState } from 'react'
-import { Play, Loader2, CheckCircle2, AlertCircle, Clock, RefreshCw, Wallet } from 'lucide-react'
+import {
+  Play,
+  Loader2,
+  CheckCircle2,
+  AlertCircle,
+  Clock,
+  RefreshCw,
+  Wallet,
+  Filter,
+  Download,
+  Calendar,
+} from 'lucide-react'
 import api from '@/lib/api'
 import { useRequireAuth } from '@/hooks/useAuth'
 
-type JobStatus = 'queued' | 'running' | 'completed' | 'failed'
+type JobStatus = 'queued' | 'running' | 'completed' | 'failed' | 'cancelled'
 
-interface Status {
+type SettlementFilters = {
+  timezone: string
+  dateFrom: string
+  dateTo: string
+  daysOfWeek: number[]
+  hourStart: number
+  hourEnd: number
+  clientIds: string[]
+  clientMode: 'include' | 'exclude'
+  subMerchantIds: string[]
+  subMerchantMode: 'include' | 'exclude'
+  paymentMethods: string[]
+  paymentMode: 'include' | 'exclude'
+  minAmount: number | null
+  maxAmount: number | null
+  includeZeroAmount: boolean
+}
+
+type SettlementPreviewOrder = {
+  id: string
+  partnerClientId: string | null
+  subMerchantId: string | null
+  channel: string
+  amount: number
+  pendingAmount: number | null
+  netAmount: number
+  createdAt: string
+}
+
+type SettlementPreview = {
+  totalOrders: number
+  totalNetAmount: number
+  batchSize: number
+  estimatedBatches: number
+  sample: SettlementPreviewOrder[]
+}
+
+type SettlementStatus = {
   settledOrders: number
   netAmount: number
   status: JobStatus
+  error: string | null
+  batches: number
+  filters: SettlementFilters
+  createdAt: string
+  updatedAt: string
+  cancelled: boolean
+  preview: SettlementPreview | null
 }
+
+type ManualFormState = {
+  dateFrom: string
+  dateTo: string
+  hourStart: string
+  hourEnd: string
+  clientIds: string
+  clientMode: 'include' | 'exclude'
+  subMerchantIds: string
+  subMerchantMode: 'include' | 'exclude'
+  paymentMethods: string
+  paymentMode: 'include' | 'exclude'
+  minAmount: string
+  maxAmount: string
+}
+
+const dayOptions: { value: number; label: string }[] = [
+  { value: 1, label: 'Senin' },
+  { value: 2, label: 'Selasa' },
+  { value: 3, label: 'Rabu' },
+  { value: 4, label: 'Kamis' },
+  { value: 5, label: 'Jumat' },
+  { value: 6, label: 'Sabtu' },
+  { value: 0, label: 'Minggu' },
+]
+
+const hourOptions = Array.from({ length: 24 }, (_, i) => ({ value: i, label: `${i.toString().padStart(2, '0')}:00` }))
+
+const splitInput = (value: string) =>
+  value
+    .split(/[,\n]/)
+    .map(v => v.trim())
+    .filter(Boolean)
+
+const formatCurrency = (value: number) =>
+  new Intl.NumberFormat('id-ID', { style: 'currency', currency: 'IDR' }).format(value)
+
+const formatNumber = (value: number) => new Intl.NumberFormat('id-ID').format(value)
 
 export default function ManualSettlementPage() {
   useRequireAuth()
 
+  const [form, setForm] = useState<ManualFormState>({
+    dateFrom: '',
+    dateTo: '',
+    hourStart: '0',
+    hourEnd: '23',
+    clientIds: '',
+    clientMode: 'include',
+    subMerchantIds: '',
+    subMerchantMode: 'include',
+    paymentMethods: '',
+    paymentMode: 'include',
+    minAmount: '',
+    maxAmount: '',
+  })
+  const [selectedDays, setSelectedDays] = useState<number[]>(dayOptions.map(d => d.value))
+  const [preview, setPreview] = useState<SettlementPreview | null>(null)
+  const [previewLoading, setPreviewLoading] = useState(false)
   const [starting, setStarting] = useState(false)
+  const [cancelling, setCancelling] = useState(false)
+  const [downloading, setDownloading] = useState(false)
   const [jobId, setJobId] = useState<string | null>(null)
-  const [status, setStatus] = useState<Status | null>(null)
+  const [status, setStatus] = useState<SettlementStatus | null>(null)
   const [error, setError] = useState('')
 
-  const start = async () => {
+  const canSubmit = form.dateFrom && form.dateTo && selectedDays.length > 0
+
+  const serializeFilters = (): Record<string, unknown> => ({
+    dateFrom: form.dateFrom,
+    dateTo: form.dateTo,
+    daysOfWeek: selectedDays,
+    hourStart: Number(form.hourStart),
+    hourEnd: Number(form.hourEnd),
+    clientIds: splitInput(form.clientIds),
+    clientMode: form.clientMode,
+    subMerchantIds: splitInput(form.subMerchantIds),
+    subMerchantMode: form.subMerchantMode,
+    paymentMethods: splitInput(form.paymentMethods),
+    paymentMode: form.paymentMode,
+    minAmount: form.minAmount ? Number(form.minAmount) : undefined,
+    maxAmount: form.maxAmount ? Number(form.maxAmount) : undefined,
+  })
+
+  const handleToggleDay = (value: number) => {
+    setSelectedDays(prev => {
+      if (prev.includes(value)) {
+        return prev.filter(v => v !== value)
+      }
+      return [...prev, value].sort((a, b) => a - b)
+    })
+  }
+
+  const handlePreview = async () => {
+    if (!canSubmit) {
+      setError('Lengkapi tanggal, hari, dan jam terlebih dahulu')
+      return
+    }
+    setError('')
+    setPreviewLoading(true)
+    try {
+      const filters = serializeFilters()
+      const res = await api.post<{ data: { preview: SettlementPreview } }>('/admin/settlement/preview', {
+        filters,
+      })
+      setPreview(res.data.data.preview)
+    } catch (err: any) {
+      setPreview(null)
+      setError(err?.response?.data?.error || 'Gagal membuat preview settlement')
+    } finally {
+      setPreviewLoading(false)
+    }
+  }
+
+  const handleStart = async () => {
+    if (!canSubmit) {
+      setError('Lengkapi filter sebelum menjalankan settlement')
+      return
+    }
     setError('')
     setStatus(null)
     setJobId(null)
     setStarting(true)
     try {
-      const res = await api.post<{ data: { jobId: string } }>('/admin/settlement/start', {})
+      const filters = serializeFilters()
+      const res = await api.post<{ data: { jobId: string } }>('/admin/settlement/start', {
+        filters,
+      })
       setJobId(res.data.data.jobId)
-    } catch (e: any) {
-      setError(e?.response?.data?.error || 'Failed to start settlement')
+    } catch (err: any) {
       setStarting(false)
+      setError(err?.response?.data?.error || 'Gagal memulai settlement')
     }
   }
 
-  // Polling status
+  const handleCancel = async () => {
+    if (!jobId) return
+    setCancelling(true)
+    setError('')
+    try {
+      await api.post(`/admin/settlement/cancel/${jobId}`, {})
+    } catch (err: any) {
+      setError(err?.response?.data?.error || 'Tidak dapat membatalkan job')
+    } finally {
+      setCancelling(false)
+    }
+  }
+
+  const handleDownload = async () => {
+    if (!jobId) return
+    setDownloading(true)
+    setError('')
+    try {
+      const res = await api.get<{ data: { detail: any } }>(`/admin/settlement/export/${jobId}`)
+      const exportFile = res.data.data.detail?.exportFile
+      if (!exportFile) {
+        setError('Summary belum tersedia untuk diunduh')
+        return
+      }
+      const binary = atob(exportFile.content)
+      const bytes = new Uint8Array(binary.length)
+      for (let i = 0; i < binary.length; i += 1) {
+        bytes[i] = binary.charCodeAt(i)
+      }
+      const blob = new Blob([bytes], { type: exportFile.mimeType || 'text/csv' })
+      const url = URL.createObjectURL(blob)
+      const link = document.createElement('a')
+      link.href = url
+      link.download = exportFile.fileName || `settlement-${jobId}.csv`
+      document.body.appendChild(link)
+      link.click()
+      document.body.removeChild(link)
+      URL.revokeObjectURL(url)
+    } catch (err: any) {
+      setError(err?.response?.data?.error || 'Gagal mengunduh summary settlement')
+    } finally {
+      setDownloading(false)
+    }
+  }
+
   useEffect(() => {
     if (!jobId) return
     const interval = setInterval(async () => {
       try {
-        const res = await api.get<{ data: Status }>(`/admin/settlement/status/${jobId}`)
+        const res = await api.get<{ data: SettlementStatus }>(`/admin/settlement/status/${jobId}`)
         const data = res.data.data
         setStatus(data)
-        if (data.status === 'completed' || data.status === 'failed') {
-          clearInterval(interval)
+        if (!['queued', 'running'].includes(data.status)) {
           setStarting(false)
+          clearInterval(interval)
         }
-      } catch (e: any) {
-        setError(e?.response?.data?.error || 'Failed to fetch status')
-        clearInterval(interval)
+      } catch (err: any) {
+        setError(err?.response?.data?.error || 'Gagal mengambil status job')
         setStarting(false)
+        clearInterval(interval)
       }
     }, 1000)
     return () => clearInterval(interval)
   }, [jobId])
 
-  const inProgress = starting || (status && (status.status === 'queued' || status.status === 'running'))
+  const inProgress = starting || (status && ['queued', 'running'].includes(status.status))
 
   const progressPercent = useMemo(() => {
-    switch (status?.status) {
-      case 'queued':
-        return 20
-      case 'running':
-        return 70
-      case 'completed':
-      case 'failed':
-        return 100
-      default:
-        return starting ? 10 : 0
-    }
-  }, [status?.status, starting])
+    if (status?.status === 'completed') return 100
+    if (status?.status === 'failed') return 100
+    if (status?.status === 'cancelled') return 100
+    if (status?.status === 'running') return 70
+    if (status?.status === 'queued') return 30
+    return starting ? 10 : 0
+  }, [starting, status?.status])
 
   const statusBadge = (s?: JobStatus) => {
     const map: Record<JobStatus, string> = {
@@ -78,6 +284,7 @@ export default function ManualSettlementPage() {
       running: 'border-sky-900/40 bg-sky-950/40 text-sky-300',
       completed: 'border-emerald-900/40 bg-emerald-950/40 text-emerald-300',
       failed: 'border-rose-900/40 bg-rose-950/40 text-rose-300',
+      cancelled: 'border-neutral-700/40 bg-neutral-900/40 text-neutral-200',
     }
     const cls = s ? map[s] : 'border-neutral-800 bg-neutral-900 text-neutral-300'
     return (
@@ -88,24 +295,70 @@ export default function ManualSettlementPage() {
     )
   }
 
+  const renderFilterSummary = () => {
+    if (!status?.filters) return null
+    const f = status.filters
+    return (
+      <div className="grid gap-2 text-xs text-neutral-400">
+        <div>
+          <span className="font-semibold text-neutral-200">Rentang Tanggal:</span>{' '}
+          {f.dateFrom} → {f.dateTo}
+        </div>
+        <div>
+          <span className="font-semibold text-neutral-200">Hari:</span>{' '}
+          {f.daysOfWeek
+            .map(day => dayOptions.find(d => d.value === day)?.label ?? day)
+            .join(', ')}
+        </div>
+        <div>
+          <span className="font-semibold text-neutral-200">Jam:</span>{' '}
+          {`${f.hourStart.toString().padStart(2, '0')}:00 - ${f.hourEnd.toString().padStart(2, '0')}:59`}
+        </div>
+        {f.clientIds.length > 0 && (
+          <div>
+            <span className="font-semibold text-neutral-200">Klien ({f.clientMode}):</span>{' '}
+            {f.clientIds.join(', ')}
+          </div>
+        )}
+        {f.subMerchantIds.length > 0 && (
+          <div>
+            <span className="font-semibold text-neutral-200">Sub Merchant ({f.subMerchantMode}):</span>{' '}
+            {f.subMerchantIds.join(', ')}
+          </div>
+        )}
+        {f.paymentMethods.length > 0 && (
+          <div>
+            <span className="font-semibold text-neutral-200">Metode Pembayaran ({f.paymentMode}):</span>{' '}
+            {f.paymentMethods.join(', ')}
+          </div>
+        )}
+        {(f.minAmount != null || f.maxAmount != null) && (
+          <div>
+            <span className="font-semibold text-neutral-200">Nominal:</span>{' '}
+            {f.minAmount != null ? formatCurrency(f.minAmount) : '—'} {'→'}{' '}
+            {f.maxAmount != null ? formatCurrency(f.maxAmount) : '—'}
+          </div>
+        )}
+      </div>
+    )
+  }
+
   return (
     <div className="min-h-screen bg-neutral-950 text-neutral-100 px-4 py-6 sm:px-6 lg:px-8">
-      <div className="mx-auto max-w-2xl space-y-6">
-        {/* Header */}
-        <header className="flex items-center justify-between">
+      <div className="mx-auto max-w-5xl space-y-6">
+        <header className="flex flex-wrap items-center justify-between gap-4">
           <div className="flex items-center gap-3">
             <div className="inline-grid h-11 w-11 place-items-center rounded-xl border border-neutral-800 bg-neutral-900">
               <Wallet size={20} />
             </div>
             <div>
               <h1 className="text-xl font-semibold tracking-tight">Manual Settlement</h1>
-              <p className="text-xs text-neutral-400">Jalankan settlement secara manual dan pantau progresnya.</p>
+              <p className="text-xs text-neutral-400">Jalankan settlement manual dengan filter yang lebih presisi.</p>
             </div>
           </div>
           {statusBadge(status?.status)}
         </header>
 
-        {/* Error banner */}
         {error && (
           <div className="rounded-xl border border-rose-900/40 bg-rose-950/40 px-3 py-2 text-sm text-rose-300">
             <div className="flex items-center gap-2">
@@ -115,109 +368,385 @@ export default function ManualSettlementPage() {
           </div>
         )}
 
-        {/* Card */}
-        <div className="rounded-2xl border border-neutral-800 bg-neutral-900/70 p-5 shadow-xl backdrop-blur supports-[backdrop-filter]:bg-neutral-900/60">
-          {/* Actions */}
-          <div className="flex flex-wrap items-center gap-2">
-            <button
-              onClick={start}
-              disabled={!!inProgress}
-              className="inline-flex items-center gap-2 rounded-xl bg-indigo-700 px-4 py-2.5 text-sm font-semibold text-white shadow hover:bg-indigo-600 disabled:opacity-60"
-            >
-              {inProgress ? <Loader2 className="h-4 w-4 animate-spin" /> : <Play className="h-4 w-4" />}
-              {inProgress ? 'Processing…' : 'Start Settlement'}
-            </button>
+        <div className="grid gap-6 lg:grid-cols-[1.2fr,1fr]">
+          <div className="space-y-4">
+            <div className="rounded-2xl border border-neutral-800 bg-neutral-900/70 p-5 shadow-xl">
+              <div className="mb-4 flex items-center gap-2 text-sm font-semibold text-neutral-200">
+                <Filter size={16} /> Filter Settlement
+              </div>
 
-            {/* Secondary info */}
-            <div className="ml-auto text-xs text-neutral-400">
-              {jobId ? (
-                <span className="inline-flex items-center gap-1">
-                  <Clock size={14} /> Job ID: <b className="font-mono">{jobId}</b>
-                </span>
-              ) : (
-                <span className="inline-flex items-center gap-1">
-                  <Clock size={14} /> Ready
-                </span>
-              )}
+              <div className="grid gap-4">
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <label className="text-xs uppercase tracking-wide text-neutral-400">
+                    Dari Tanggal
+                    <div className="mt-1 flex items-center gap-2 rounded-lg border border-neutral-800 bg-neutral-950 px-3 py-2">
+                      <Calendar size={16} className="text-neutral-500" />
+                      <input
+                        type="date"
+                        value={form.dateFrom}
+                        onChange={e => setForm(prev => ({ ...prev, dateFrom: e.target.value }))}
+                        className="w-full bg-transparent text-sm outline-none"
+                      />
+                    </div>
+                  </label>
+                  <label className="text-xs uppercase tracking-wide text-neutral-400">
+                    Sampai Tanggal
+                    <div className="mt-1 flex items-center gap-2 rounded-lg border border-neutral-800 bg-neutral-950 px-3 py-2">
+                      <Calendar size={16} className="text-neutral-500" />
+                      <input
+                        type="date"
+                        value={form.dateTo}
+                        onChange={e => setForm(prev => ({ ...prev, dateTo: e.target.value }))}
+                        className="w-full bg-transparent text-sm outline-none"
+                      />
+                    </div>
+                  </label>
+                </div>
+
+                <div>
+                  <span className="text-xs uppercase tracking-wide text-neutral-400">Hari</span>
+                  <div className="mt-2 flex flex-wrap gap-2">
+                    {dayOptions.map(day => {
+                      const active = selectedDays.includes(day.value)
+                      return (
+                        <button
+                          key={day.value}
+                          type="button"
+                          onClick={() => handleToggleDay(day.value)}
+                          className={`rounded-lg border px-3 py-1 text-xs transition ${
+                            active
+                              ? 'border-indigo-500/70 bg-indigo-600/20 text-indigo-200'
+                              : 'border-neutral-800 bg-neutral-950 text-neutral-400 hover:border-neutral-700'
+                          }`}
+                        >
+                          {day.label}
+                        </button>
+                      )
+                    })}
+                  </div>
+                </div>
+
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <label className="text-xs uppercase tracking-wide text-neutral-400">
+                    Jam Mulai
+                    <select
+                      className="mt-1 w-full rounded-lg border border-neutral-800 bg-neutral-950 px-3 py-2 text-sm outline-none"
+                      value={form.hourStart}
+                      onChange={e => setForm(prev => ({ ...prev, hourStart: e.target.value }))}
+                    >
+                      {hourOptions.map(opt => (
+                        <option key={opt.value} value={opt.value}>
+                          {opt.label}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                  <label className="text-xs uppercase tracking-wide text-neutral-400">
+                    Jam Akhir
+                    <select
+                      className="mt-1 w-full rounded-lg border border-neutral-800 bg-neutral-950 px-3 py-2 text-sm outline-none"
+                      value={form.hourEnd}
+                      onChange={e => setForm(prev => ({ ...prev, hourEnd: e.target.value }))}
+                    >
+                      {hourOptions.map(opt => (
+                        <option key={opt.value} value={opt.value}>
+                          {opt.label}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                </div>
+
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <div className="space-y-2">
+                    <label className="text-xs uppercase tracking-wide text-neutral-400">
+                      ID Client (pisahkan dengan koma)
+                      <textarea
+                        value={form.clientIds}
+                        onChange={e => setForm(prev => ({ ...prev, clientIds: e.target.value }))}
+                        rows={2}
+                        className="mt-1 w-full rounded-lg border border-neutral-800 bg-neutral-950 px-3 py-2 text-sm outline-none"
+                      />
+                    </label>
+                    <label className="flex items-center gap-2 text-xs text-neutral-400">
+                      <input
+                        type="checkbox"
+                        checked={form.clientMode === 'exclude'}
+                        onChange={e =>
+                          setForm(prev => ({ ...prev, clientMode: e.target.checked ? 'exclude' : 'include' }))
+                        }
+                        className="h-3.5 w-3.5 rounded border-neutral-700 bg-neutral-900"
+                      />
+                      Kecualikan daftar di atas
+                    </label>
+                  </div>
+                  <div className="space-y-2">
+                    <label className="text-xs uppercase tracking-wide text-neutral-400">
+                      ID Sub Merchant
+                      <textarea
+                        value={form.subMerchantIds}
+                        onChange={e => setForm(prev => ({ ...prev, subMerchantIds: e.target.value }))}
+                        rows={2}
+                        className="mt-1 w-full rounded-lg border border-neutral-800 bg-neutral-950 px-3 py-2 text-sm outline-none"
+                      />
+                    </label>
+                    <label className="flex items-center gap-2 text-xs text-neutral-400">
+                      <input
+                        type="checkbox"
+                        checked={form.subMerchantMode === 'exclude'}
+                        onChange={e =>
+                          setForm(prev => ({ ...prev, subMerchantMode: e.target.checked ? 'exclude' : 'include' }))
+                        }
+                        className="h-3.5 w-3.5 rounded border-neutral-700 bg-neutral-900"
+                      />
+                      Kecualikan daftar di atas
+                    </label>
+                  </div>
+                </div>
+
+                <div className="space-y-2">
+                  <label className="text-xs uppercase tracking-wide text-neutral-400">
+                    Metode Pembayaran
+                    <textarea
+                      value={form.paymentMethods}
+                      onChange={e => setForm(prev => ({ ...prev, paymentMethods: e.target.value }))}
+                      rows={2}
+                      className="mt-1 w-full rounded-lg border border-neutral-800 bg-neutral-950 px-3 py-2 text-sm outline-none"
+                    />
+                  </label>
+                  <label className="flex items-center gap-2 text-xs text-neutral-400">
+                    <input
+                      type="checkbox"
+                      checked={form.paymentMode === 'exclude'}
+                      onChange={e =>
+                        setForm(prev => ({ ...prev, paymentMode: e.target.checked ? 'exclude' : 'include' }))
+                      }
+                      className="h-3.5 w-3.5 rounded border-neutral-700 bg-neutral-900"
+                    />
+                    Kecualikan daftar di atas
+                  </label>
+                </div>
+
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <label className="text-xs uppercase tracking-wide text-neutral-400">
+                    Nominal Minimum (IDR)
+                    <input
+                      type="number"
+                      value={form.minAmount}
+                      onChange={e => setForm(prev => ({ ...prev, minAmount: e.target.value }))}
+                      className="mt-1 w-full rounded-lg border border-neutral-800 bg-neutral-950 px-3 py-2 text-sm outline-none"
+                    />
+                  </label>
+                  <label className="text-xs uppercase tracking-wide text-neutral-400">
+                    Nominal Maksimum (IDR)
+                    <input
+                      type="number"
+                      value={form.maxAmount}
+                      onChange={e => setForm(prev => ({ ...prev, maxAmount: e.target.value }))}
+                      className="mt-1 w-full rounded-lg border border-neutral-800 bg-neutral-950 px-3 py-2 text-sm outline-none"
+                    />
+                  </label>
+                </div>
+              </div>
+
+              <div className="mt-6 flex flex-wrap items-center gap-3">
+                <button
+                  onClick={handlePreview}
+                  disabled={!canSubmit || previewLoading}
+                  className="inline-flex items-center gap-2 rounded-xl border border-neutral-700 bg-neutral-900 px-4 py-2.5 text-sm font-semibold text-neutral-200 hover:bg-neutral-800 disabled:opacity-60"
+                >
+                  {previewLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Filter className="h-4 w-4" />}
+                  Preview
+                </button>
+                <button
+                  onClick={handleStart}
+                  disabled={!canSubmit || !!inProgress}
+                  className="inline-flex items-center gap-2 rounded-xl bg-indigo-700 px-4 py-2.5 text-sm font-semibold text-white shadow hover:bg-indigo-600 disabled:opacity-60"
+                >
+                  {inProgress ? <Loader2 className="h-4 w-4 animate-spin" /> : <Play className="h-4 w-4" />}
+                  {inProgress ? 'Memproses…' : 'Mulai Settlement'}
+                </button>
+                {jobId && (
+                  <div className="ml-auto text-xs text-neutral-400">
+                    <span className="inline-flex items-center gap-1">
+                      <Clock size={14} /> Job ID: <b className="font-mono text-neutral-200">{jobId}</b>
+                    </span>
+                  </div>
+                )}
+              </div>
             </div>
+
+            {preview && (
+              <div className="rounded-2xl border border-neutral-800 bg-neutral-900/70 p-5 shadow-xl">
+                <div className="mb-4 flex items-center gap-2 text-sm font-semibold text-neutral-200">
+                  <Filter size={16} /> Preview Hasil
+                </div>
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <div className="rounded-xl border border-neutral-800 bg-neutral-950 p-4">
+                    <div className="text-xs text-neutral-400">Perkiraan Order</div>
+                    <div className="mt-1 text-xl font-semibold">{formatNumber(preview.totalOrders)}</div>
+                  </div>
+                  <div className="rounded-xl border border-neutral-800 bg-neutral-950 p-4">
+                    <div className="text-xs text-neutral-400">Total Settlement</div>
+                    <div className="mt-1 text-xl font-semibold">{formatCurrency(preview.totalNetAmount)}</div>
+                  </div>
+                  <div className="rounded-xl border border-neutral-800 bg-neutral-950 p-4">
+                    <div className="text-xs text-neutral-400">Batch Size</div>
+                    <div className="mt-1 text-xl font-semibold">{formatNumber(preview.batchSize)}</div>
+                  </div>
+                  <div className="rounded-xl border border-neutral-800 bg-neutral-950 p-4">
+                    <div className="text-xs text-neutral-400">Perkiraan Batch</div>
+                    <div className="mt-1 text-xl font-semibold">{formatNumber(preview.estimatedBatches)}</div>
+                  </div>
+                </div>
+                {preview.sample.length > 0 && (
+                  <div className="mt-5">
+                    <div className="mb-2 text-xs font-semibold uppercase text-neutral-400">Sample Order</div>
+                    <div className="overflow-hidden rounded-lg border border-neutral-800">
+                      <table className="w-full min-w-[600px] table-auto text-sm">
+                        <thead className="bg-neutral-900 text-xs uppercase text-neutral-400">
+                          <tr>
+                            <th className="px-3 py-2 text-left">Order ID</th>
+                            <th className="px-3 py-2 text-left">Client</th>
+                            <th className="px-3 py-2 text-left">Sub Merchant</th>
+                            <th className="px-3 py-2 text-left">Channel</th>
+                            <th className="px-3 py-2 text-right">Net Amount</th>
+                            <th className="px-3 py-2 text-right">Pending Amount</th>
+                            <th className="px-3 py-2 text-left">Created At</th>
+                          </tr>
+                        </thead>
+                        <tbody className="bg-neutral-950/80">
+                          {preview.sample.map(order => (
+                            <tr key={order.id} className="border-t border-neutral-900/60">
+                              <td className="px-3 py-2 font-mono text-xs text-indigo-200">{order.id}</td>
+                              <td className="px-3 py-2 text-xs text-neutral-300">{order.partnerClientId ?? '—'}</td>
+                              <td className="px-3 py-2 text-xs text-neutral-300">{order.subMerchantId ?? '—'}</td>
+                              <td className="px-3 py-2 text-xs text-neutral-300">{order.channel}</td>
+                              <td className="px-3 py-2 text-right text-xs text-neutral-200">{formatCurrency(order.netAmount)}</td>
+                              <td className="px-3 py-2 text-right text-xs text-neutral-400">
+                                {order.pendingAmount != null ? formatCurrency(order.pendingAmount) : '—'}
+                              </td>
+                              <td className="px-3 py-2 text-xs text-neutral-400">{order.createdAt}</td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+                )}
+              </div>
+            )}
           </div>
 
-          {/* Progress */}
-          {(inProgress || status) && (
-            <div className="mt-5 space-y-4">
+          <div className="space-y-4">
+            <div className="rounded-2xl border border-neutral-800 bg-neutral-900/70 p-5 shadow-xl">
+              <div className="mb-4 text-sm font-semibold text-neutral-200">Status Job</div>
+
               <div className="w-full overflow-hidden rounded-lg border border-neutral-800 bg-neutral-950">
                 <div
                   className={`h-3 transition-all ${
-                    status?.status === 'failed' ? 'bg-rose-600' : 'bg-indigo-600'
+                    status?.status === 'failed' ? 'bg-rose-600' : status?.status === 'cancelled' ? 'bg-neutral-600' : 'bg-indigo-600'
                   }`}
                   style={{ width: `${progressPercent}%` }}
                 />
               </div>
 
-              {/* Status row */}
-              {status && (status.status === 'queued' || status.status === 'running') && (
-                <div className="flex items-center gap-2 text-sm text-neutral-300">
+              {status && ['queued', 'running'].includes(status.status) && (
+                <div className="mt-4 flex items-center gap-2 text-sm text-neutral-300">
                   <Loader2 className="h-4 w-4 animate-spin" />
-                  <span>{status.status === 'queued' ? 'Waiting to run…' : 'Processing…'}</span>
+                  <span>{status.status === 'queued' ? 'Menunggu antrian…' : 'Sedang diproses…'}</span>
                 </div>
               )}
 
-              {/* Completed */}
               {status && status.status === 'completed' && (
-                <div className="rounded-xl border border-emerald-900/40 bg-emerald-950/40 p-3 text-sm text-emerald-300">
+                <div className="mt-4 rounded-xl border border-emerald-900/40 bg-emerald-950/40 p-3 text-sm text-emerald-300">
                   <div className="flex items-start gap-2">
                     <CheckCircle2 className="mt-0.5 h-4 w-4" />
                     <div className="space-y-1">
                       <div className="font-medium">Settlement selesai</div>
-                      <div className="text-emerald-200/90">
-                        Settled Orders: <b>{status.settledOrders.toLocaleString('id-ID')}</b>
-                      </div>
-                      <div className="text-emerald-200/90">
-                        Net Amount:{' '}
-                        <b>
-                          {status.netAmount.toLocaleString('id-ID', {
-                            style: 'currency',
-                            currency: 'IDR',
-                          })}
-                        </b>
-                      </div>
+                      <div className="text-emerald-200/90">Order Settled: <b>{formatNumber(status.settledOrders)}</b></div>
+                      <div className="text-emerald-200/90">Total Settlement: <b>{formatCurrency(status.netAmount)}</b></div>
+                      <div className="text-emerald-200/90">Total Batch: <b>{formatNumber(status.batches)}</b></div>
                     </div>
                   </div>
                 </div>
               )}
 
-              {/* Failed */}
               {status && status.status === 'failed' && (
-                <div className="rounded-xl border border-rose-900/40 bg-rose-950/40 p-3 text-sm text-rose-300">
+                <div className="mt-4 rounded-xl border border-rose-900/40 bg-rose-950/40 p-3 text-sm text-rose-300">
                   <div className="flex items-start gap-2">
                     <AlertCircle className="mt-0.5 h-4 w-4" />
                     <div>
                       <div className="font-medium">Settlement gagal</div>
-                      <div className="text-rose-200/90">Silakan cek logs dan jalankan ulang.</div>
+                      <div className="text-rose-200/90">{status.error || 'Silakan cek log untuk detail.'}</div>
                     </div>
                   </div>
                 </div>
               )}
 
-              {/* Restart hint when finished */}
-              {status && (status.status === 'completed' || status.status === 'failed') && (
-                <div className="pt-2">
-                  <button
-                    onClick={start}
-                    className="inline-flex items-center gap-2 rounded-xl border border-neutral-800 bg-neutral-900 px-3 py-2 text-xs font-semibold hover:bg-neutral-800"
-                  >
-                    <RefreshCw className="h-4 w-4" />
-                    Jalankan ulang
-                  </button>
+              {status && status.status === 'cancelled' && (
+                <div className="mt-4 rounded-xl border border-neutral-700/40 bg-neutral-900/60 p-3 text-sm text-neutral-200">
+                  <div className="flex items-start gap-2">
+                    <AlertCircle className="mt-0.5 h-4 w-4" />
+                    <div>
+                      <div className="font-medium">Job dibatalkan</div>
+                      <div className="text-neutral-300/80">{status.error || 'Job dihentikan oleh admin.'}</div>
+                    </div>
+                  </div>
                 </div>
               )}
+
+              {status && renderFilterSummary()}
+
+              <div className="mt-6 flex flex-wrap gap-2">
+                {jobId && inProgress && (
+                  <button
+                    onClick={handleCancel}
+                    disabled={cancelling}
+                    className="inline-flex items-center gap-2 rounded-xl border border-neutral-700 bg-neutral-900 px-3 py-2 text-xs font-semibold text-neutral-200 hover:bg-neutral-800 disabled:opacity-60"
+                  >
+                    {cancelling ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
+                    Batalkan Job
+                  </button>
+                )}
+                {jobId && !inProgress && (
+                  <button
+                    onClick={handleDownload}
+                    disabled={downloading}
+                    className="inline-flex items-center gap-2 rounded-xl border border-neutral-700 bg-neutral-900 px-3 py-2 text-xs font-semibold text-neutral-200 hover:bg-neutral-800 disabled:opacity-60"
+                  >
+                    {downloading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Download className="h-4 w-4" />}
+                    Unduh Summary
+                  </button>
+                )}
+              </div>
             </div>
-          )}
+
+            {status && (status.status === 'completed' || status.status === 'failed' || status.status === 'cancelled') && (
+              <div className="rounded-2xl border border-neutral-800 bg-neutral-900/70 p-5 text-xs text-neutral-400">
+                <div className="grid gap-2">
+                  <div>
+                    <span className="font-semibold text-neutral-200">Dibuat:</span>{' '}
+                    {new Date(status.createdAt).toLocaleString('id-ID')}
+                  </div>
+                  <div>
+                    <span className="font-semibold text-neutral-200">Update Terakhir:</span>{' '}
+                    {new Date(status.updatedAt).toLocaleString('id-ID')}
+                  </div>
+                  {status.error && (
+                    <div>
+                      <span className="font-semibold text-neutral-200">Keterangan:</span>{' '}
+                      {status.error}
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
+          </div>
         </div>
 
-        {/* Footnote */}
         <p className="text-xs text-neutral-500">
-          Catatan: Progress persentase bersifat indikatif (queued → running → selesai/gagal).
+          Catatan: Filter menggunakan zona waktu Asia/Jakarta. Preview memberikan estimasi sebelum job dijalankan.
         </p>
       </div>
     </div>

--- a/src/controller/admin/settlement.controller.ts
+++ b/src/controller/admin/settlement.controller.ts
@@ -1,8 +1,350 @@
 import { Response } from 'express'
-import { runManualSettlement, resetSettlementState, restartSettlementChecker } from '../../cron/settlement'
+import { z } from 'zod'
+import { fromZonedTime, utcToZonedTime } from 'date-fns-tz'
+import type { Prisma } from '@prisma/client'
+import { prisma } from '../../core/prisma'
+import {
+  runManualSettlement,
+  resetSettlementState,
+  restartSettlementChecker,
+  MANUAL_SETTLEMENT_BATCH_SIZE,
+} from '../../cron/settlement'
 import { AuthRequest } from '../../middleware/auth'
 import { logAdminAction } from '../../util/adminLog'
-import { startSettlementJob, getSettlementJob } from '../../worker/settlementJob'
+import {
+  startSettlementJob,
+  getSettlementJob,
+  cancelSettlementJob,
+  type StartSettlementJobOptions,
+} from '../../worker/settlementJob'
+import { computeSettlement } from '../../service/feeSettlement'
+import type { ManualSettlementFilters, ManualSettlementPreview, ManualSettlementPreviewOrder } from '../../types/manualSettlement'
+
+const JAKARTA_TZ = 'Asia/Jakarta'
+const PREVIEW_FETCH_SIZE = 500
+const PREVIEW_SAMPLE_LIMIT = 20
+
+const parseStringArray = (input: unknown): string[] => {
+  if (Array.isArray(input)) {
+    return input
+      .map(v => String(v).trim())
+      .filter(Boolean)
+  }
+  if (typeof input === 'string') {
+    return input
+      .split(',')
+      .map(v => v.trim())
+      .filter(Boolean)
+  }
+  return []
+}
+
+const settlementFilterSchema = z.object({
+  dateFrom: z.string().min(1, 'dateFrom is required'),
+  dateTo: z.string().min(1, 'dateTo is required'),
+  daysOfWeek: z
+    .preprocess(input => {
+      if (Array.isArray(input)) {
+        return input.map(v => Number(v))
+      }
+      if (typeof input === 'string') {
+        return input
+          .split(',')
+          .map(v => Number(v.trim()))
+          .filter(n => !Number.isNaN(n))
+      }
+      return []
+    }, z.array(z.number().int().min(0).max(6)).nonempty('daysOfWeek is required')),
+  hourStart: z.coerce.number().int().min(0).max(23),
+  hourEnd: z.coerce.number().int().min(0).max(23),
+  clientIds: z
+    .preprocess(input => parseStringArray(input), z.array(z.string().min(1)).optional())
+    .optional(),
+  clientMode: z.enum(['include', 'exclude']).optional(),
+  subMerchantIds: z
+    .preprocess(input => parseStringArray(input), z.array(z.string().min(1)).optional())
+    .optional(),
+  subMerchantMode: z.enum(['include', 'exclude']).optional(),
+  paymentMethods: z
+    .preprocess(input => parseStringArray(input), z.array(z.string().min(1)).optional())
+    .optional(),
+  paymentMode: z.enum(['include', 'exclude']).optional(),
+  minAmount: z
+    .preprocess(input => {
+      if (input === '' || input === null || input === undefined) {
+        return undefined
+      }
+      const num = Number(input)
+      return Number.isFinite(num) ? num : undefined
+    }, z.number().nonnegative().optional())
+    .optional(),
+  maxAmount: z
+    .preprocess(input => {
+      if (input === '' || input === null || input === undefined) {
+        return undefined
+      }
+      const num = Number(input)
+      return Number.isFinite(num) ? num : undefined
+    }, z.number().nonnegative().optional())
+    .optional(),
+  includeZeroAmount: z
+    .preprocess(input => {
+      if (input === '' || input === null || input === undefined) {
+        return undefined
+      }
+      if (typeof input === 'boolean') {
+        return input
+      }
+      if (typeof input === 'string') {
+        return input === 'true' || input === '1'
+      }
+      return undefined
+    }, z.boolean().optional())
+    .optional(),
+})
+
+type SettlementFilterInput = z.infer<typeof settlementFilterSchema>
+
+type PreviewQueryOrder = {
+  id: string
+  partnerClientId: string | null
+  subMerchantId: string | null
+  pendingAmount: number | null
+  amount: number
+  channel: string
+  createdAt: Date
+  partnerClient: { feePercent: number | null; feeFlat: number | null } | null
+}
+
+const resolveFilterPayload = (body: any): unknown => {
+  if (body && typeof body === 'object' && 'filters' in body) {
+    return (body as Record<string, unknown>).filters
+  }
+  return body
+}
+
+const buildFilters = (input: unknown): ManualSettlementFilters => {
+  const parsed = settlementFilterSchema.parse(input) as SettlementFilterInput
+
+  const startDate = fromZonedTime(`${parsed.dateFrom}T00:00:00`, JAKARTA_TZ)
+  const endDate = fromZonedTime(`${parsed.dateTo}T23:59:59.999`, JAKARTA_TZ)
+
+  if (Number.isNaN(startDate.getTime()) || Number.isNaN(endDate.getTime())) {
+    throw new Error('Invalid date range')
+  }
+
+  if (startDate > endDate) {
+    throw new Error('dateFrom must be before or equal to dateTo')
+  }
+
+  if (parsed.hourStart > parsed.hourEnd) {
+    throw new Error('hourStart must be before or equal to hourEnd')
+  }
+
+  if (
+    parsed.minAmount != null &&
+    parsed.maxAmount != null &&
+    parsed.minAmount > parsed.maxAmount
+  ) {
+    throw new Error('minAmount cannot be greater than maxAmount')
+  }
+
+  const days = Array.from(new Set(parsed.daysOfWeek)).sort()
+
+  return {
+    timezone: JAKARTA_TZ,
+    dateFrom: parsed.dateFrom,
+    dateTo: parsed.dateTo,
+    startDate,
+    endDate,
+    daysOfWeek: days,
+    hourStart: parsed.hourStart,
+    hourEnd: parsed.hourEnd,
+    clientIds: (parsed.clientIds ?? []).map(v => v.trim()).filter(Boolean),
+    clientMode: parsed.clientMode ?? 'include',
+    subMerchantIds: (parsed.subMerchantIds ?? []).map(v => v.trim()).filter(Boolean),
+    subMerchantMode: parsed.subMerchantMode ?? 'include',
+    paymentMethods: (parsed.paymentMethods ?? []).map(v => v.trim()).filter(Boolean),
+    paymentMode: parsed.paymentMode ?? 'include',
+    minAmount: parsed.minAmount ?? null,
+    maxAmount: parsed.maxAmount ?? null,
+    includeZeroAmount: parsed.includeZeroAmount ?? false,
+  }
+}
+
+const buildOrderWhere = (filters: ManualSettlementFilters): Prisma.OrderWhereInput => {
+  const where: Prisma.OrderWhereInput = {
+    status: 'PAID',
+    partnerClientId:
+      filters.clientIds.length > 0
+        ? filters.clientMode === 'exclude'
+          ? { notIn: filters.clientIds, not: null }
+          : { in: filters.clientIds }
+        : { not: null },
+    createdAt: {
+      gte: filters.startDate,
+      lte: filters.endDate,
+    },
+  }
+
+  if (filters.subMerchantIds.length > 0) {
+    where.subMerchantId =
+      filters.subMerchantMode === 'exclude'
+        ? { notIn: filters.subMerchantIds }
+        : { in: filters.subMerchantIds }
+  }
+
+  if (filters.paymentMethods.length > 0) {
+    where.channel =
+      filters.paymentMode === 'exclude'
+        ? { notIn: filters.paymentMethods }
+        : { in: filters.paymentMethods }
+  }
+
+  return where
+}
+
+const isWithinDayHour = (date: Date, filters: ManualSettlementFilters) => {
+  const local = utcToZonedTime(date, filters.timezone)
+  const day = local.getDay()
+  if (!filters.daysOfWeek.includes(day)) {
+    return false
+  }
+  const hour = local.getHours()
+  return hour >= filters.hourStart && hour <= filters.hourEnd
+}
+
+const amountMatchesFilters = (amount: number, filters: ManualSettlementFilters) => {
+  if (!Number.isFinite(amount)) {
+    return false
+  }
+  if (filters.minAmount != null && amount < filters.minAmount) {
+    return false
+  }
+  if (filters.maxAmount != null && amount > filters.maxAmount) {
+    return false
+  }
+  if (!filters.includeZeroAmount && amount <= 0) {
+    return false
+  }
+  return true
+}
+
+const computeManualNetAmount = (order: PreviewQueryOrder): number | null => {
+  let net = Number(order.pendingAmount ?? 0)
+  if (!Number.isFinite(net) || net <= 0) {
+    const gross = Number(order.amount ?? 0)
+    if (!Number.isFinite(gross) || gross <= 0) {
+      return null
+    }
+    const percent = order.partnerClient?.feePercent ?? 0
+    const flat = order.partnerClient?.feeFlat ?? 0
+    const computed = computeSettlement(gross, { percent, flat })
+    net = computed.settlement
+  }
+
+  if (!Number.isFinite(net) || net <= 0) {
+    return null
+  }
+
+  return net
+}
+
+const buildSettlementPreview = async (
+  filters: ManualSettlementFilters,
+): Promise<ManualSettlementPreview> => {
+  const baseWhere = buildOrderWhere(filters)
+  const sample: ManualSettlementPreviewOrder[] = []
+  const batchSize = MANUAL_SETTLEMENT_BATCH_SIZE
+
+  let cursor: { createdAt: Date; id: string } | null = null
+  let totalOrders = 0
+  let totalNetAmount = 0
+
+  while (true) {
+    const where: Prisma.OrderWhereInput = {
+      ...baseWhere,
+      ...(cursor
+        ? {
+            OR: [
+              { createdAt: { gt: cursor.createdAt } },
+              { createdAt: cursor.createdAt, id: { gt: cursor.id } },
+            ],
+          }
+        : {}),
+    }
+
+    const orders = await prisma.order.findMany({
+      where,
+      orderBy: [
+        { createdAt: 'asc' },
+        { id: 'asc' },
+      ],
+      take: PREVIEW_FETCH_SIZE,
+      select: {
+        id: true,
+        partnerClientId: true,
+        subMerchantId: true,
+        pendingAmount: true,
+        amount: true,
+        channel: true,
+        createdAt: true,
+        partnerClient: { select: { feePercent: true, feeFlat: true } },
+      },
+    })
+
+    if (!orders.length) {
+      break
+    }
+
+    for (const order of orders) {
+      if (!isWithinDayHour(order.createdAt, filters)) {
+        continue
+      }
+      const net = computeManualNetAmount(order as PreviewQueryOrder)
+      if (net == null) {
+        continue
+      }
+      if (!amountMatchesFilters(net, filters)) {
+        continue
+      }
+
+      totalOrders += 1
+      totalNetAmount += net
+
+      if (sample.length < PREVIEW_SAMPLE_LIMIT) {
+        const local = utcToZonedTime(order.createdAt, filters.timezone)
+        sample.push({
+          id: order.id,
+          partnerClientId: order.partnerClientId ?? null,
+          subMerchantId: order.subMerchantId ?? null,
+          channel: order.channel,
+          amount: order.amount ?? 0,
+          pendingAmount: order.pendingAmount ?? null,
+          netAmount: net,
+          createdAt: local.toISOString(),
+        })
+      }
+    }
+
+    if (orders.length < PREVIEW_FETCH_SIZE) {
+      break
+    }
+
+    const last = orders[orders.length - 1]
+    cursor = { createdAt: last.createdAt, id: last.id }
+  }
+
+  const estimatedBatches = totalOrders ? Math.ceil(totalOrders / batchSize) : 0
+
+  return {
+    totalOrders,
+    totalNetAmount,
+    batchSize,
+    estimatedBatches,
+    sample,
+  }
+}
 
 export async function manualSettlement(req: AuthRequest, res: Response) {
   resetSettlementState()
@@ -14,12 +356,43 @@ export async function manualSettlement(req: AuthRequest, res: Response) {
   res.json({ data: result })
 }
 
-export async function startSettlement(req: AuthRequest, res: Response) {
-  const jobId = startSettlementJob()
-  if (req.userId) {
-    await logAdminAction(req.userId, 'manualSettlementStart', null, { jobId })
+export async function previewSettlement(req: AuthRequest, res: Response) {
+  try {
+    const filters = buildFilters(resolveFilterPayload(req.body))
+    const preview = await buildSettlementPreview(filters)
+    res.json({ data: { filters, preview } })
+  } catch (error: any) {
+    if (error instanceof z.ZodError) {
+      return res.status(400).json({ error: error.issues[0]?.message ?? 'Invalid request' })
+    }
+    if (error instanceof Error) {
+      return res.status(400).json({ error: error.message })
+    }
+    return res.status(500).json({ error: 'Failed to build preview' })
   }
-  res.json({ data: { jobId } })
+}
+
+export async function startSettlement(req: AuthRequest, res: Response) {
+  try {
+    const filters = buildFilters(resolveFilterPayload(req.body))
+    const options: StartSettlementJobOptions = {
+      filters,
+      createdBy: req.userId ?? undefined,
+    }
+    const jobId = startSettlementJob(options)
+    if (req.userId) {
+      await logAdminAction(req.userId, 'manualSettlementStart', null, { jobId, filters })
+    }
+    res.json({ data: { jobId } })
+  } catch (error: any) {
+    if (error instanceof z.ZodError) {
+      return res.status(400).json({ error: error.issues[0]?.message ?? 'Invalid request' })
+    }
+    if (error instanceof Error) {
+      return res.status(400).json({ error: error.message })
+    }
+    return res.status(500).json({ error: 'Failed to start settlement job' })
+  }
 }
 
 export function settlementStatus(req: AuthRequest, res: Response) {
@@ -27,7 +400,63 @@ export function settlementStatus(req: AuthRequest, res: Response) {
   if (!job) {
     return res.status(404).json({ error: 'Job not found' })
   }
-  const { settledOrders, netAmount, status } = job
-  res.json({ data: { settledOrders, netAmount, status } })
+  const { settledOrders, netAmount, status, error, batches, filters, createdAt, updatedAt, cancelled, preview } = job
+  res.json({
+    data: {
+      settledOrders,
+      netAmount,
+      status,
+      error: error ?? null,
+      batches,
+      filters,
+      createdAt: createdAt.toISOString(),
+      updatedAt: updatedAt.toISOString(),
+      cancelled: cancelled ?? false,
+      preview: preview ?? null,
+    },
+  })
 }
 
+export function cancelSettlement(req: AuthRequest, res: Response) {
+  const cancelled = cancelSettlementJob(req.params.jobId)
+  if (!cancelled) {
+    return res.status(400).json({ error: 'Unable to cancel job' })
+  }
+  res.json({ data: { cancelled: true } })
+}
+
+export async function downloadSettlementSummary(req: AuthRequest, res: Response) {
+  const { jobId } = req.params
+  if (!jobId) {
+    return res.status(400).json({ error: 'jobId is required' })
+  }
+
+  const logEntry = await prisma.adminLog.findFirst({
+    where: {
+      action: {
+        in: [
+          'manualSettlementJobCompleted',
+          'manualSettlementJobFailed',
+          'manualSettlementJobCancelled',
+        ],
+      },
+      detail: {
+        path: ['jobId'],
+        equals: jobId,
+      },
+    },
+    orderBy: { createdAt: 'desc' },
+  })
+
+  if (!logEntry) {
+    return res.status(404).json({ error: 'Summary not found' })
+  }
+
+  res.json({
+    data: {
+      id: logEntry.id,
+      createdAt: logEntry.createdAt.toISOString(),
+      detail: logEntry.detail ?? null,
+    },
+  })
+}

--- a/src/route/admin/settlement.routes.ts
+++ b/src/route/admin/settlement.routes.ts
@@ -4,6 +4,9 @@ import {
   manualSettlement,
   startSettlement,
   settlementStatus,
+  previewSettlement,
+  cancelSettlement,
+  downloadSettlementSummary,
 } from '../../controller/admin/settlement.controller'
 import {
   adjustSettlements,
@@ -18,8 +21,11 @@ const router = Router()
 router.use(requireAdminAuth)
 
 router.post('/', manualSettlement)
+router.post('/preview', previewSettlement)
 router.post('/start', startSettlement)
 router.get('/status/:jobId', settlementStatus)
+router.post('/cancel/:jobId', cancelSettlement)
+router.get('/export/:jobId', downloadSettlementSummary)
 router.post('/adjust', adjustSettlements)
 router.post('/adjust/job', startSettlementAdjustmentJob)
 router.get('/adjust/job/:jobId', settlementAdjustmentStatus)

--- a/src/types/manualSettlement.ts
+++ b/src/types/manualSettlement.ts
@@ -1,0 +1,38 @@
+export type ManualSettlementFilters = {
+  timezone: string
+  dateFrom: string
+  dateTo: string
+  startDate: Date
+  endDate: Date
+  daysOfWeek: number[]
+  hourStart: number
+  hourEnd: number
+  clientIds: string[]
+  clientMode: 'include' | 'exclude'
+  subMerchantIds: string[]
+  subMerchantMode: 'include' | 'exclude'
+  paymentMethods: string[]
+  paymentMode: 'include' | 'exclude'
+  minAmount?: number | null
+  maxAmount?: number | null
+  includeZeroAmount: boolean
+}
+
+export type ManualSettlementPreviewOrder = {
+  id: string
+  partnerClientId: string | null
+  subMerchantId: string | null
+  channel: string
+  amount: number
+  pendingAmount: number | null
+  netAmount: number
+  createdAt: string
+}
+
+export type ManualSettlementPreview = {
+  totalOrders: number
+  totalNetAmount: number
+  batchSize: number
+  estimatedBatches: number
+  sample: ManualSettlementPreviewOrder[]
+}

--- a/src/worker/settlementJob.ts
+++ b/src/worker/settlementJob.ts
@@ -1,7 +1,15 @@
 import { v4 as uuidv4 } from 'uuid'
-import { runManualSettlement, resetSettlementState, restartSettlementChecker } from '../cron/settlement'
+import {
+  runManualSettlement,
+  resetSettlementState,
+  restartSettlementChecker,
+  type ManualSettlementRunOptions,
+} from '../cron/settlement'
+import type { ManualSettlementFilters, ManualSettlementPreview } from '../types/manualSettlement'
+import { logAdminAction } from '../util/adminLog'
+import { createCsvExport } from '../util/export'
 
-export type JobStatus = 'queued' | 'running' | 'completed' | 'failed'
+export type JobStatus = 'queued' | 'running' | 'completed' | 'failed' | 'cancelled'
 
 export interface SettlementJob {
   id: string
@@ -9,28 +17,111 @@ export interface SettlementJob {
   settledOrders: number
   netAmount: number
   error?: string
+  filters: ManualSettlementFilters
+  createdBy?: string
+  createdAt: Date
+  updatedAt: Date
+  batches: number
+  cancelRequested?: boolean
+  cancelled?: boolean
+  preview?: ManualSettlementPreview
 }
 
 const jobs = new Map<string, SettlementJob>()
 const queue: SettlementJob[] = []
 let current: SettlementJob | null = null
 
+export type StartSettlementJobOptions = {
+  filters: ManualSettlementFilters
+  createdBy?: string
+  preview?: ManualSettlementPreview
+}
+
+async function logJobOutcome(job: SettlementJob, outcome: JobStatus) {
+  if (!job.createdBy) {
+    return
+  }
+
+  const detail: Record<string, any> = {
+    jobId: job.id,
+    status: outcome,
+    settledOrders: job.settledOrders,
+    netAmount: job.netAmount,
+    batches: job.batches,
+    filters: job.filters,
+    preview: job.preview ?? null,
+    cancelled: job.cancelled ?? false,
+    error: job.error ?? null,
+  }
+
+  if (outcome === 'completed') {
+    detail.exportFile = createCsvExport({
+      headers: ['Metric', 'Value'],
+      rows: [
+        ['Job ID', job.id],
+        ['Status', 'COMPLETED'],
+        ['Settled Orders', job.settledOrders],
+        ['Net Amount', job.netAmount],
+        ['Batches', job.batches],
+      ],
+      fileNamePrefix: `manual-settlement-${job.id}`,
+    })
+  }
+
+  const actionMap: Record<JobStatus, string> = {
+    queued: 'manualSettlementJobQueued',
+    running: 'manualSettlementJobRunning',
+    completed: 'manualSettlementJobCompleted',
+    failed: 'manualSettlementJobFailed',
+    cancelled: 'manualSettlementJobCancelled',
+  }
+
+  try {
+    await logAdminAction(job.createdBy, actionMap[outcome], job.id, detail)
+  } catch (err) {
+    console.error('[SettlementJob] Failed to log admin action', err)
+  }
+}
+
 function runNext() {
   if (current || queue.length === 0) return
   const job = queue.shift()!
   current = job
   job.status = 'running'
+  job.updatedAt = new Date()
   resetSettlementState()
-  runManualSettlement(p => {
-    job.settledOrders = p.settledOrders
-    job.netAmount = p.netAmount
-  })
-    .then(() => {
-      job.status = 'completed'
+  void logJobOutcome(job, 'running')
+
+  const options: ManualSettlementRunOptions = {
+    filters: job.filters,
+    shouldCancel: () => job.cancelRequested === true,
+    onProgress: progress => {
+      job.settledOrders = progress.settledOrders
+      job.netAmount = progress.netAmount
+      job.batches = progress.batchesProcessed
+      job.updatedAt = new Date()
+    },
+  }
+
+  runManualSettlement(options)
+    .then(async result => {
+      job.settledOrders = result.settledOrders
+      job.netAmount = result.netAmount
+      job.batches = result.batches
+      job.cancelled = result.cancelled || job.cancelRequested
+      job.status = job.cancelled ? 'cancelled' : 'completed'
+      job.updatedAt = new Date()
+      if (job.cancelled && !job.error) {
+        job.error = 'Cancelled'
+      }
+      await logJobOutcome(job, job.status)
     })
-    .catch(err => {
-      job.status = 'failed'
+    .catch(async err => {
       job.error = err instanceof Error ? err.message : String(err)
+      job.status = job.cancelRequested ? 'cancelled' : 'failed'
+      job.cancelled = job.status === 'cancelled'
+      job.updatedAt = new Date()
+      await logJobOutcome(job, job.status)
     })
     .finally(() => {
       restartSettlementChecker('')
@@ -39,19 +130,59 @@ function runNext() {
     })
 }
 
-export function startSettlementJob() {
+export function startSettlementJob(options: StartSettlementJobOptions) {
+  const now = new Date()
   const job: SettlementJob = {
     id: uuidv4(),
     status: 'queued',
     settledOrders: 0,
     netAmount: 0,
+    filters: options.filters,
+    createdBy: options.createdBy,
+    createdAt: now,
+    updatedAt: now,
+    batches: 0,
+    preview: options.preview,
   }
   jobs.set(job.id, job)
   queue.push(job)
+  void logJobOutcome(job, 'queued')
   runNext()
   return job.id
 }
 
 export function getSettlementJob(jobId: string) {
   return jobs.get(jobId)
+}
+
+export function cancelSettlementJob(jobId: string) {
+  const job = jobs.get(jobId)
+  if (!job) {
+    return false
+  }
+
+  if (job.status === 'completed' || job.status === 'failed' || job.status === 'cancelled') {
+    return false
+  }
+
+  if (job.status === 'queued') {
+    const idx = queue.findIndex(j => j.id === jobId)
+    if (idx >= 0) {
+      queue.splice(idx, 1)
+    }
+    job.status = 'cancelled'
+    job.cancelRequested = true
+    job.cancelled = true
+    job.updatedAt = new Date()
+    void logJobOutcome(job, 'cancelled')
+    return true
+  }
+
+  if (job.status === 'running') {
+    job.cancelRequested = true
+    job.updatedAt = new Date()
+    return true
+  }
+
+  return false
 }

--- a/test/adminSettlement.routes.test.ts
+++ b/test/adminSettlement.routes.test.ts
@@ -8,8 +8,8 @@ const settlement = require('../src/cron/settlement')
 let called = 0
 settlement.runManualSettlement = async (cb?: any) => {
   called++
-  cb?.({ settledOrders: 2, netAmount: 200, batchSettled: 2, batchAmount: 200 })
-  return { settledOrders: 2, netAmount: 200 }
+  cb?.({ settledOrders: 2, netAmount: 200, batchSettled: 2, batchAmount: 200, batchesProcessed: 1 })
+  return { settledOrders: 2, netAmount: 200, batches: 1, cancelled: false }
 }
 settlement.restartSettlementChecker = () => {}
 
@@ -20,6 +20,8 @@ const {
   manualSettlement,
   startSettlement,
   settlementStatus,
+  previewSettlement,
+  cancelSettlement,
 } = require('../src/controller/admin/settlement.controller')
 
 const app = express()
@@ -32,9 +34,23 @@ app.post('/settlement/start', (req, res) => {
   ;(req as any).userId = 'admin1'
   startSettlement(req as any, res)
 })
+app.post('/settlement/preview', (req, res) => {
+  previewSettlement(req as any, res)
+})
 app.get('/settlement/status/:jobId', (req, res) => {
   settlementStatus(req as any, res)
 })
+app.post('/settlement/cancel/:jobId', (req, res) => {
+  cancelSettlement(req as any, res)
+})
+
+const baseFilters = {
+  dateFrom: '2024-01-01',
+  dateTo: '2024-01-02',
+  daysOfWeek: [1],
+  hourStart: 0,
+  hourEnd: 23,
+}
 
 test('manual settlement runs without batches param', async () => {
   called = 0
@@ -43,8 +59,14 @@ test('manual settlement runs without batches param', async () => {
   assert.equal(called, 1)
 })
 
+test('preview settlement with filters', async () => {
+  const res = await request(app).post('/settlement/preview').send({ filters: baseFilters })
+  assert.equal(res.status, 200)
+  assert.ok(res.body.data.preview)
+})
+
 test('start and check settlement job status', async () => {
-  const startRes = await request(app).post('/settlement/start').send({})
+  const startRes = await request(app).post('/settlement/start').send({ filters: baseFilters })
   assert.equal(startRes.status, 200)
   const jobId = startRes.body.data.jobId
   assert.ok(jobId)


### PR DESCRIPTION
## Summary
- expand the manual settlement admin page with granular filters, preview data, cancellation, and summary download actions
- validate settlement filters on the backend, add preview/cancel/export endpoints, and forward filter metadata into the worker
- enhance the settlement job worker with cancellation support, logging-backed CSV exports, and updated tests for the new flow

## Testing
- npm test -- --runTestsByPath test/adminSettlement.routes.test.ts *(fails: script could not locate pattern)*

------
https://chatgpt.com/codex/tasks/task_e_68df8f97e1f083289b8592cc5f2038a7