### PR TITLE
Replace utcToZonedTime usage with toZonedTime

### DIFF
--- a/src/controller/admin/settlement.controller.ts
+++ b/src/controller/admin/settlement.controller.ts
@@ -1,6 +1,6 @@
 import { Response } from 'express'
 import { z } from 'zod'
-import { fromZonedTime, utcToZonedTime } from 'date-fns-tz'
+import { fromZonedTime, toZonedTime } from 'date-fns-tz'
 import type { Prisma } from '@prisma/client'
 import { prisma } from '../../core/prisma'
 import {
@@ -205,7 +205,7 @@ const buildOrderWhere = (filters: ManualSettlementFilters): Prisma.OrderWhereInp
 }
 
 const isWithinDayHour = (date: Date, filters: ManualSettlementFilters) => {
-  const local = utcToZonedTime(date, filters.timezone)
+  const local = toZonedTime(date, filters.timezone)
   const day = local.getDay()
   if (!filters.daysOfWeek.includes(day)) {
     return false
@@ -313,7 +313,7 @@ const buildSettlementPreview = async (
       totalNetAmount += net
 
       if (sample.length < PREVIEW_SAMPLE_LIMIT) {
-        const local = utcToZonedTime(order.createdAt, filters.timezone)
+        const local = toZonedTime(order.createdAt, filters.timezone)
         sample.push({
           id: order.id,
           partnerClientId: order.partnerClientId ?? null,

--- a/src/cron/settlement.ts
+++ b/src/cron/settlement.ts
@@ -3,7 +3,7 @@ import axios from 'axios'
 import https from 'https'
 import os from 'os'
 import pLimit from 'p-limit'
-import { utcToZonedTime } from 'date-fns-tz'
+import { toZonedTime } from 'date-fns-tz'
 import type { Prisma } from '@prisma/client'
 import { prisma } from '../core/prisma'
 import { config } from '../config'
@@ -135,7 +135,7 @@ const ensureSortedCursor = (orders: { createdAt: Date; id: string }[]): Cursor =
 }
 
 const isWithinDayHour = (date: Date, filters: ManualSettlementFilters) => {
-  const local = utcToZonedTime(date, filters.timezone)
+  const local = toZonedTime(date, filters.timezone)
   const day = local.getDay()
   if (!filters.daysOfWeek.includes(day)) {
     return false


### PR DESCRIPTION
## Summary
- replace deprecated `utcToZonedTime` usage with `toZonedTime` in admin settlement controller and settlement cron
- update helpers to call `toZonedTime(date, timezone)` when deriving localized timestamps

## Testing
- npm run build *(fails: existing type errors in unrelated files such as missing Prisma exports)*

------
https://chatgpt.com/codex/tasks/task_e_68df96ed27c88328801a0755a8d27aa9