### PR TITLE
Format settlement timestamps in WIB

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "tsx --test src/utils/dashboard.test.ts src/utils/piroBankMap.test.ts src/tests/merchants/merchant-index.test.tsx src/tests/loan.test.tsx src/tests/settlement-adjust.test.tsx"
+    "test": "tsx --test src/utils/dashboard.test.ts src/utils/piroBankMap.test.ts src/tests/merchants/merchant-index.test.tsx src/tests/loan.test.tsx src/tests/settlement-adjust.test.tsx src/utils/datetime.test.ts"
   },
   "dependencies": {
     "@headlessui/react": "^2.2.4",

--- a/frontend/src/pages/admin/settlement.tsx
+++ b/frontend/src/pages/admin/settlement.tsx
@@ -15,6 +15,7 @@ import {
 } from 'lucide-react'
 import api from '@/lib/api'
 import { useRequireAuth } from '@/hooks/useAuth'
+import { formatDateTimeInWIB } from '@/utils/datetime'
 
 type JobStatus = 'queued' | 'running' | 'completed' | 'failed' | 'cancelled'
 
@@ -626,7 +627,7 @@ export default function ManualSettlementPage() {
                               <td className="px-3 py-2 text-right text-xs text-neutral-400">
                                 {order.pendingAmount != null ? formatCurrency(order.pendingAmount) : '—'}
                               </td>
-                              <td className="px-3 py-2 text-xs text-neutral-400">{order.createdAt}</td>
+                              <td className="px-3 py-2 text-xs text-neutral-400">{formatDateTimeInWIB(order.createdAt)}</td>
                             </tr>
                           ))}
                         </tbody>
@@ -727,11 +728,11 @@ export default function ManualSettlementPage() {
                 <div className="grid gap-2">
                   <div>
                     <span className="font-semibold text-neutral-200">Dibuat:</span>{' '}
-                    {new Date(status.createdAt).toLocaleString('id-ID')}
+                    {formatDateTimeInWIB(status.createdAt)}
                   </div>
                   <div>
                     <span className="font-semibold text-neutral-200">Update Terakhir:</span>{' '}
-                    {new Date(status.updatedAt).toLocaleString('id-ID')}
+                    {formatDateTimeInWIB(status.updatedAt)}
                   </div>
                   {status.error && (
                     <div>

--- a/frontend/src/tests/loan.test.tsx
+++ b/frontend/src/tests/loan.test.tsx
@@ -377,6 +377,7 @@ test('starts loan settlement job and polls until completion', async () => {
     subMerchantId: 'sub-1',
     startDate: toWibIso(start),
     endDate: toWibIso(end),
+    dryRun: false,
     note: 'Bulk job',
   })
 

--- a/frontend/src/utils/datetime.test.ts
+++ b/frontend/src/utils/datetime.test.ts
@@ -1,0 +1,16 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { formatDateTimeInWIB } from './datetime'
+
+describe('formatDateTimeInWIB', () => {
+  it('formats ISO strings using Asia/Jakarta timezone', () => {
+    const formatted = formatDateTimeInWIB('2024-01-15T03:04:05Z')
+    assert.equal(formatted, '15 Jan 2024, 10.04.05 WIB')
+  })
+
+  it('returns a placeholder for invalid input', () => {
+    const formatted = formatDateTimeInWIB('invalid-date')
+    assert.equal(formatted, '—')
+  })
+})

--- a/frontend/src/utils/datetime.ts
+++ b/frontend/src/utils/datetime.ts
@@ -1,0 +1,23 @@
+const WIB_TIME_ZONE = 'Asia/Jakarta'
+
+const wibDateTimeFormatter = new Intl.DateTimeFormat('id-ID', {
+  timeZone: WIB_TIME_ZONE,
+  dateStyle: 'medium',
+  timeStyle: 'medium',
+  hour12: false,
+})
+
+export const formatDateTimeInWIB = (value: string | number | Date | null | undefined) => {
+  if (value == null) {
+    return '—'
+  }
+
+  const date = typeof value === 'string' || typeof value === 'number' ? new Date(value) : value
+  if (Number.isNaN(date.getTime())) {
+    return '—'
+  }
+
+  return `${wibDateTimeFormatter.format(date)} WIB`
+}
+
+export const WIB_TIMEZONE_NAME = WIB_TIME_ZONE


### PR DESCRIPTION
## Summary
- format settlement preview sample rows and job timestamps with a WIB-specific formatter
- add a reusable Intl-based helper and test to ensure Asia/Jakarta formatting
- adjust frontend test coverage to include the new helper and reflect current loan payload shape

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df9e3dab548328bd9c976fed7b0482