### PR TITLE
Fix Prisma metadata sanitization helper typing

### DIFF
--- a/test/coercePrismaJsonInput.test.ts
+++ b/test/coercePrismaJsonInput.test.ts
@@ -1,0 +1,57 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { objectEnumValues } from '@prisma/client/runtime/library'
+import type { Prisma } from '@prisma/client'
+
+import {
+  coercePrismaJsonInput,
+  type PrismaSanitizedJsonValue,
+} from '../src/service/loanSettlement'
+
+test('coercePrismaJsonInput produces Prisma-compatible metadata inputs', async (t) => {
+  type OrderMetadata = Prisma.OrderUpdateInput['metadata']
+  type LoanEntryMetadata = Prisma.LoanEntryUpdateInput['metadata']
+
+  const mockPrisma = {
+    order: {
+      async update(args: { data: { metadata: OrderMetadata } }) {
+        return args.data.metadata
+      },
+    },
+    loanEntry: {
+      async update(args: { data: { metadata: LoanEntryMetadata } }) {
+        return args.data.metadata
+      },
+    },
+  }
+
+  const dbNullValue =
+    objectEnumValues.instances.DbNull as unknown as PrismaSanitizedJsonValue
+  const jsonNullValue =
+    objectEnumValues.instances.JsonNull as unknown as PrismaSanitizedJsonValue
+  const scalarValue: PrismaSanitizedJsonValue = 'metadata'
+  const objectValue: PrismaSanitizedJsonValue = { foo: 'bar' }
+
+  const scenarios = [
+    ['db null metadata', dbNullValue],
+    ['json null metadata', jsonNullValue],
+    ['scalar metadata', scalarValue],
+    ['object metadata', objectValue],
+  ] as const
+
+  for (const [label, sanitized] of scenarios) {
+    await t.test(label, async () => {
+      const orderResult = await mockPrisma.order.update({
+        data: { metadata: coercePrismaJsonInput(sanitized) },
+      })
+
+      const loanEntryResult = await mockPrisma.loanEntry.update({
+        data: { metadata: coercePrismaJsonInput(sanitized) },
+      })
+
+      assert.deepEqual(orderResult, sanitized)
+      assert.deepEqual(loanEntryResult, sanitized)
+    })
+  }
+})


### PR DESCRIPTION
## Summary
- align loan settlement metadata sanitization with Prisma metadata input types and typed null sentinels
- add a coercion helper to map sanitized metadata back to Prisma update inputs
- cover the helper with unit tests for DB null, JSON null, scalar, and object metadata scenarios

## Testing
- JWT_SECRET=test node --test -r ts-node/register test/coercePrismaJsonInput.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e01726d84c832890386c92670c8db5