### PR TITLE
Fix reversal cleanup filters to avoid unsupported notIn

### DIFF
--- a/src/service/loanSettlement.ts
+++ b/src/service/loanSettlement.ts
@@ -439,6 +439,8 @@ const buildCleanupReversalWhere = ({
     throw new Error('startDate must be before or equal to endDate')
   }
 
+  const reversalPath = ['reversal'] as const
+
   const nullExclusions: unknown[] = [null]
 
   if (runtimeJsonNull !== undefined) {
@@ -449,15 +451,35 @@ const buildCleanupReversalWhere = ({
     nullExclusions.push(PRISMA_DB_NULL)
   }
 
+  const metadataExclusionFilters: Record<string, unknown>[] = [
+    { metadata: null },
+    { metadata: { path: reversalPath, equals: null } },
+  ]
+
+  for (const exclusion of nullExclusions) {
+    if (exclusion === null) {
+      continue
+    }
+
+    metadataExclusionFilters.push({
+      metadata: { path: reversalPath, equals: exclusion },
+    })
+
+    if (exclusion === PRISMA_JSON_NULL) {
+      metadataExclusionFilters.push({ metadata: PRISMA_JSON_NULL })
+    }
+
+    if (exclusion === PRISMA_DB_NULL) {
+      metadataExclusionFilters.push({ metadata: PRISMA_DB_NULL })
+    }
+  }
+
   const where: Record<string, unknown> = {
     loanedAt: {
       gte: start,
       lte: end,
     },
-    metadata: {
-      path: ['reversal'],
-      notIn: nullExclusions as unknown[],
-    },
+    NOT: metadataExclusionFilters,
   }
 
   if (subMerchantId) {

--- a/test/reverseSettlementToLnSettle.test.ts
+++ b/test/reverseSettlementToLnSettle.test.ts
@@ -586,9 +586,13 @@ test('preview cleanup reversal metadata returns affected order ids without persi
   assert.deepEqual(res.body.updatedOrderIds, ['order-1', 'order-2'])
   assert.equal(orderUpdateCalls, 0)
   assert.deepEqual(capturedWhere.subMerchantId, 'sub-1')
-  assert.deepEqual(capturedWhere.metadata?.path, ['reversal'])
-  assert.ok(Array.isArray(capturedWhere.metadata?.notIn))
-  assert.ok(capturedWhere.metadata?.notIn?.includes(null))
+  assert.ok(Array.isArray(capturedWhere.NOT))
+  assert.ok(
+    capturedWhere.NOT?.some(
+      (clause: any) =>
+        clause?.metadata?.path?.[0] === 'reversal' && clause?.metadata?.equals === null,
+    ),
+  )
   })
 
 test('cleanup reversal metadata resets loanedAt and logs admin action', async () => {


### PR DESCRIPTION
## Summary
- replace the reversal metadata JSON filter in both the service and CLI script to use NOT clauses that exclude null, Prisma.JsonNull, and Prisma.DbNull
- update the related unit and integration tests to capture the new Prisma where shape and ensure the unsupported notIn predicate is gone

## Testing
- TS_NODE_TRANSPILE_ONLY=1 node --test -r ts-node/register test/cleanupReversalMetadata.test.ts test/reverseSettlementToLnSettle.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e01dc7623c83289a4beaec9d8a50f6