### PR TITLE
Fix cleanup reversal metadata filters

### DIFF
--- a/scripts/cleanupReversalMetadata.ts
+++ b/scripts/cleanupReversalMetadata.ts
@@ -149,43 +149,33 @@ function buildWhereClause(options: CleanupOptions) {
 
   const reversalPath = ['reversal'] as const
 
-  const nullExclusions: unknown[] = [null]
-
-  if (PRISMA_JSON_NULL !== undefined) {
-    nullExclusions.push(PRISMA_JSON_NULL)
-  }
-
-  if (PRISMA_DB_NULL !== undefined) {
-    nullExclusions.push(PRISMA_DB_NULL)
-  }
-
   const metadataExclusionFilters: Record<string, unknown>[] = [
-    { metadata: null },
+    { metadata: { equals: null } },
     { metadata: { path: reversalPath, equals: null } },
   ]
 
-  for (const exclusion of nullExclusions) {
-    if (exclusion === null) {
-      continue
-    }
+  if (PRISMA_JSON_NULL !== undefined) {
+    metadataExclusionFilters.push(
+      { metadata: { equals: PRISMA_JSON_NULL } },
+      { metadata: { path: reversalPath, equals: PRISMA_JSON_NULL } },
+    )
+  }
 
-    metadataExclusionFilters.push({
-      metadata: { path: reversalPath, equals: exclusion },
-    })
-
-    if (exclusion === PRISMA_JSON_NULL) {
-      metadataExclusionFilters.push({ metadata: PRISMA_JSON_NULL })
-    }
-
-    if (exclusion === PRISMA_DB_NULL) {
-      metadataExclusionFilters.push({ metadata: PRISMA_DB_NULL })
-    }
+  if (PRISMA_DB_NULL !== undefined) {
+    metadataExclusionFilters.push(
+      { metadata: { equals: PRISMA_DB_NULL } },
+      { metadata: { path: reversalPath, equals: PRISMA_DB_NULL } },
+    )
   }
 
   const where: Record<string, unknown> = {
     loanedAt: {
       gte: start,
       lte: end,
+    },
+    metadata: {
+      path: reversalPath,
+      not: PRISMA_JSON_NULL ?? null,
     },
     NOT: metadataExclusionFilters,
   }

--- a/src/service/loanSettlement.ts
+++ b/src/service/loanSettlement.ts
@@ -441,43 +441,33 @@ const buildCleanupReversalWhere = ({
 
   const reversalPath = ['reversal'] as const
 
-  const nullExclusions: unknown[] = [null]
-
-  if (runtimeJsonNull !== undefined) {
-    nullExclusions.push(PRISMA_JSON_NULL)
-  }
-
-  if (runtimeDbNull !== undefined) {
-    nullExclusions.push(PRISMA_DB_NULL)
-  }
-
   const metadataExclusionFilters: Record<string, unknown>[] = [
-    { metadata: null },
+    { metadata: { equals: null } },
     { metadata: { path: reversalPath, equals: null } },
   ]
 
-  for (const exclusion of nullExclusions) {
-    if (exclusion === null) {
-      continue
-    }
+  if (runtimeJsonNull !== undefined) {
+    metadataExclusionFilters.push(
+      { metadata: { equals: PRISMA_JSON_NULL } },
+      { metadata: { path: reversalPath, equals: PRISMA_JSON_NULL } },
+    )
+  }
 
-    metadataExclusionFilters.push({
-      metadata: { path: reversalPath, equals: exclusion },
-    })
-
-    if (exclusion === PRISMA_JSON_NULL) {
-      metadataExclusionFilters.push({ metadata: PRISMA_JSON_NULL })
-    }
-
-    if (exclusion === PRISMA_DB_NULL) {
-      metadataExclusionFilters.push({ metadata: PRISMA_DB_NULL })
-    }
+  if (runtimeDbNull !== undefined) {
+    metadataExclusionFilters.push(
+      { metadata: { equals: PRISMA_DB_NULL } },
+      { metadata: { path: reversalPath, equals: PRISMA_DB_NULL } },
+    )
   }
 
   const where: Record<string, unknown> = {
     loanedAt: {
       gte: start,
       lte: end,
+    },
+    metadata: {
+      path: reversalPath,
+      not: PRISMA_JSON_NULL ?? null,
     },
     NOT: metadataExclusionFilters,
   }


### PR DESCRIPTION
## Summary
- normalize the cleanup reversal query to use JSON equals/not filters and require reversal metadata in the loan settlement service
- mirror the safer metadata filter construction in the CLI cleanup script so both paths behave consistently
- extend tests to assert structured metadata filters and verify the admin cleanup endpoint succeeds against populated reversal metadata

## Testing
- TS_NODE_TRANSPILE_ONLY=1 node --test -r ts-node/register test/cleanupReversalMetadata.test.ts test/reverseSettlementToLnSettle.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e02169a7a4832896ae9a35f188a6f9